### PR TITLE
EFSA-83: fix DiD daemon initialization

### DIFF
--- a/run_container.sh
+++ b/run_container.sh
@@ -40,7 +40,7 @@ docker run --privileged -d --rm \
     -v "$WORKSPACE_PATH:$WORKSPACE_PATH" \
     $INPUT_MOUNT \
     efsa-pipeline \
-    tail -f /dev/null
+    dockerd-entrypoint.sh
 
 docker exec -it "$CONTAINER_NAME" /bin/sh
 docker stop "$CONTAINER_NAME"


### PR DESCRIPTION
Replaced tail command with dockerd-entrypoint.sh to properly start the
Docker daemon inside the container. This enables docker commands to
work within the container environment.