### PR TITLE
EFSA-83: do not share network with host within container

### DIFF
--- a/run_container.sh
+++ b/run_container.sh
@@ -36,7 +36,6 @@ echo "Type 'exit' when you're done to return to your host system."
 echo ""
 
 docker run --privileged -d --rm \
-    --network=host \
     -v /etc/ssl/certs:/etc/ssl/certs:ro \
     -v /usr/share/ca-certificates:/usr/share/ca-certificates:ro \
     --name "$CONTAINER_NAME" \


### PR DESCRIPTION
Removed shared network for container. It worked locally, but failed on remote VM