### PR TITLE
no-issue: mod_genome_filename optional

### DIFF
--- a/docs/validation/CONFIG_GUIDE.md
+++ b/docs/validation/CONFIG_GUIDE.md
@@ -31,7 +31,7 @@ This document defines the **JSON** configuration file that `ConfigManager` uses 
 | Key | Type | Required | Description |
 |---|---|:---:|---|
 | `ref_genome_filename` | GenomeConfig | ✅ | Reference genome (FASTA or GenBank) |
-| `mod_genome_filename` | GenomeConfig | ✅ | Modified genome (FASTA or GenBank) |
+| `mod_genome_filename` | GenomeConfig | ❌ | Modified genome (FASTA or GenBank) |
 | `ref_plasmid_filename` | GenomeConfig | ❌ | Reference plasmid (FASTA or GenBank) |
 | `mod_plasmid_filename` | GenomeConfig | ❌ | Modified plasmid (FASTA or GenBank) |
 | `reads` | List[ReadConfig] | ✅ | Read files (FASTQ/BAM), minimum one |
@@ -41,7 +41,7 @@ This document defines the **JSON** configuration file that `ConfigManager` uses 
 
 **Important:**
 - All file paths must be **relative to the config file directory**
-- At minimum, provide `ref_genome_filename`,`mod_genome_filename` and `reads`
+- At minimum, provide `ref_genome_filename` and `reads`
 
 ---
 
@@ -51,7 +51,7 @@ This document defines the **JSON** configuration file that `ConfigManager` uses 
 
 | Format | Extensions | 
 |--------|-----------|
-| FASTA | `.fa`, `.fasta`, `.fna` | 
+| FASTA | `.fa`, `.fasta`, `.fna`, `.faa` |
 | GenBank | `.gb`, `.gbk`, `.genbank` |
 
 ### Feature Files
@@ -59,7 +59,7 @@ This document defines the **JSON** configuration file that `ConfigManager` uses 
 | Format | Extensions | 
 |--------|-----------|
 | GFF | `.gff`, `.gff3` |
-| GTF | `.gtf` | 
+| GTF | `.gtf`, `.gff2` |
 | BED | `.bed` | 
 
 ### Read Files
@@ -211,10 +211,11 @@ These settings customize validation behavior without modifying code.
 ### Global Options (`options` field)
 
 **Allowed global options:**
-- `threads`: Number of threads for parallel processing (positive integer, default: 8)
-  - System automatically detects CPU cores and warns if threads exceed available cores
+- `threads`: Number of threads for parallel processing (positive integer, default: auto-detect)
+  - When omitted or set to `null`, the system auto-detects based on available CPU cores
+  - System warns if threads exceed available cores
 - `validation_level`: `"strict"`, `"trust"`, or `"minimal"` (default: `"strict"`)
-- `logging_level`: `"DEBUG"`, `"INFO"`, `"WARNING"`, `"ERROR"`, or `"CRITICAL"` (default: `"INFO"`)
+- `logging_level`: `"DEBUG"`, `"INFO"`, `"WARNING"`, or `"ERROR"` (default: `"INFO"`)
   - Controls console logging verbosity
 
 **Example:**
@@ -262,7 +263,6 @@ Simplest valid configuration with required fields only:
 ```json
 {
   "ref_genome_filename": {"filename": "ref.fasta"},
-  "mod_genome_filename": {"filename": "mod.fasta"},
   "reads": [
     {"filename": "reads.fastq", "ngs_type": "illumina"}
   ]

--- a/docs/validation/PERFORMANCE.md
+++ b/docs/validation/PERFORMANCE.md
@@ -17,8 +17,8 @@ sudo apt-get install pigz pbzip2
 ```
 
 **Performance gains:**
-- `pigz` - parallel gzip (2-4x faster)
-- `pbzip2` - parallel bzip2 (3-6x faster)
+- `pigz` - parallel gzip 
+- `pbzip2` - parallel bzip2 
 
 ## Validation Level Selection
 

--- a/docs/validation/SETTINGS.md
+++ b/docs/validation/SETTINGS.md
@@ -19,12 +19,10 @@ The validation module supports three validation levels to balance thoroughness a
 - Performs comprehensive quality checks
 - Generates detailed statistics
 - Recommended for first-time data processing
-- Ensures highest data quality
 
 **Use when:**
 - Processing data for the first time
 - Data quality is uncertain
-- Detailed statistics are needed
 
 ### Trust Mode
 - Validates only the first sequence

--- a/modules/validation/validation-pkg/tests/test_config_manager.py
+++ b/modules/validation/validation-pkg/tests/test_config_manager.py
@@ -136,18 +136,23 @@ class TestConfigManager:
         with pytest.raises((ConfigurationError, ValueError), match="Missing required field: ref_genome_filename"):
             ConfigManager.load(str(config_file))
     
-    def test_missing_required_field_mod_genome(self, temp_dir):
-        """Test error when mod_genome_filename is missing."""
+    def test_mod_genome_is_optional(self, temp_dir):
+        """Test that mod_genome_filename is optional."""
+        (temp_dir / "ref.fasta").write_text(">seq1\nATCG\n")
+        (temp_dir / "reads.fastq").write_text("@read1\nATCG\n+\nIIII\n")
+
         config = {
             "ref_genome_filename": {"filename": "ref.fasta"},
             "reads": [{"filename": "reads.fastq", "ngs_type": "illumina"}]
         }
-        
+
         config_file = temp_dir / "config.json"
         config_file.write_text(json.dumps(config))
-        
-        with pytest.raises((ConfigurationError, ValueError), match="Missing required field: mod_genome_filename"):
-            ConfigManager.load(str(config_file))
+
+        loaded_config = ConfigManager.load(str(config_file))
+        assert loaded_config.ref_genome is not None
+        assert loaded_config.mod_genome is None
+        assert len(loaded_config.reads) == 1
     
     def test_missing_required_field_reads(self, temp_dir):
         """Test error when reads field is missing."""


### PR DESCRIPTION
- mod_genome_filename in config file changed from required to optional
- removed CRITICAL lvl of logging (useless)