### PR TITLE
no-issue: fix github actions

### DIFF
--- a/.github/workflows/WORKFLOWS_GUIDE.md
+++ b/.github/workflows/WORKFLOWS_GUIDE.md
@@ -1,26 +1,36 @@
 # Workflow Structure and Guidelines
 
-This document outlines the GitHub Actions workflows used within the repository, differentiating explicitly between validation checks and automation tasks, along with their intended purpose and rules.  
+This document outlines the GitHub Actions workflows used within the repository, differentiating between validation checks and automation tasks, along with their intended purpose and rules.
 
+## Repository Variables
+
+The workflows rely on repository variables configured in:
+
+Settings → Secrets and variables → Actions → Variables
+
+Current values used in this repository:
+
+| Variable | Value |
+|---------|------|
+| PROJECT_PREFIX | EFSA |
+| IGNORE_PREFIX | no-issue |
 
 ## Validation Checks
-File is prefixed with **check**. Validation workflows explicitly ensure code quality, conventions, and standards. They run on every Pull Request targeting the main branch.  
+Files are prefixed with **check**. Validation workflows enforce repository conventions and standards. They run on every Pull Request targeting the `main` branch.
 
-**Important:** These workflows explicitly block merging PRs if checks fail. Make sure to fix reported issues promptly.
+**Important:** These workflows block merging PRs if checks fail.
 
-| Workflow                 | Trigger                             | Rules Enforced / Purpose                                                                |
-| ------------------------ | ----------------------------------- | --------------------------------------------------------------------------------------- |
-| **Branch Naming Check**  | `on: pull_request (branches: main)` | Branches must follow: `feature/EFSA-#ISSUE_branch_name`, `bugfix/...`, or `docs/...` |
-| **Commit Message Check** | `on: pull_request (branches: main)` | Commits must follow: `EFSA-#ISSUE: Your Vommit Message`                                   |
+| Workflow                 | Trigger                             | Rules Enforced / Purpose |
+|--------------------------|-------------------------------------|--------------------------|
+| **Branch Naming Check**  | `on: pull_request (branches: main)` | Branch names must follow `feature/PROJECT_PREFIX-#_branch_name`, `bugfix/...`, or `docs/...`; branches starting with `IGNORE_PREFIX` are allowed and skipped. |
+| **Commit Message Check** | `on: pull_request (branches: main)` | Commit messages must follow `PROJECT_PREFIX-#ISSUE: Your commit message`, or start with `IGNORE_PREFIX`. |
 
+## Automation Workflows
+Files are prefixed with **auto**. Automation workflows handle routine tasks like notifications, issue linking, and repository organization. They are not intended to enforce merge-blocking validation rules.
 
-## Automation Workflows (automation/ folder)
-File is prefixed with **auto**. Automation workflows handle routine tasks like notifications, linking issues, and maintaining repository organization. They are explicitly prefixed with "Automation:" and **do not** block PR merges.
-
-| Workflow                   | Trigger                                 | Automated Task / Purpose                                         |
-| -------------------------- | --------------------------------------- | ---------------------------------------------------------------- |
-| **Issue Prefixer**         | `issues [opened]`                       | Automatically prefixes issue titles with `PROJECT_PREFIX-#ISSUE` |
-| **Branch-Issue Linking**   | `push [feature/**, bugfix/**, docs/**]` | Comments on issue when associated branches are created/pushed.  |
-| **PR Opened Notification** | `pull_request [opened]`                 | Comments on issue when related PR is opened                         |
-| **PR Merged Notification** | `pull_request [closed]`       | Comments on issue upon PR merge completion                          |
-
+| Workflow                   | Trigger                                 | Automated Task / Purpose |
+|---------------------------|------------------------------------------|--------------------------|
+| **Issue Prefixer**         | `issues [opened]`                        | Automatically prefixes issue titles with `PROJECT_PREFIX-#ISSUE`. |
+| **Branch-Issue Linking**   | `push [feature/**, bugfix/**, docs/**]`  | Comments on the related issue when an associated branch is created or pushed. |
+| **PR Opened Notification** | `pull_request [opened]`                  | Comments on the related issue when a PR is opened. |
+| **PR Merged Notification** | `pull_request [closed]`                  | Comments on the related issue when a PR is merged. |

--- a/.github/workflows/auto-issue-prefix.yaml
+++ b/.github/workflows/auto-issue-prefix.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Prefix issue title
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const prefix = "${{ vars.PROJECT_PREFIX }}";
             const issueNumber = context.issue.number;

--- a/.github/workflows/check-branch-name.yaml
+++ b/.github/workflows/check-branch-name.yaml
@@ -24,7 +24,7 @@ jobs:
             exit 0
           fi
 
-          # Enforce naming cinvention check
+          # Enforce naming convention check
           if ! [[ $BRANCH =~ ^(feature|bugfix|docs)/${ISSUE_PREFIX}-[0-9]+_.+ ]]; then
             echo "❗ Branch name is invalid. Must follow pattern:"
             echo "  (feature|bugfix|docs)/${ISSUE_PREFIX}-<number>_your_branch_name"

--- a/.github/workflows/check-commit-message.yaml
+++ b/.github/workflows/check-commit-message.yaml
@@ -1,22 +1,41 @@
-- name: Check commit message format
-  run: |
-    ISSUE_PREFIX="${{ vars.PROJECT_PREFIX }}"
-    
-    # Fetch main branch
-    git fetch origin main:main
-    
-    # Check only commits not in main
-    invalid_msgs=$(
-      git log --no-merges --format="%s" main..HEAD \
-      | grep -vE "^(${IGNORE_PREFIX}|${ISSUE_PREFIX}-[0-9]+: .+)" \
-      || true
-    )
-    
-    if [ -n "$invalid_msgs" ]; then
-      echo "🚨 Invalid commit message(s) detected:"
-      echo "$invalid_msgs"
-      echo "❗ Expected format: '${ISSUE_PREFIX}-<#ISSUE>: Your commit message' or start with '${IGNORE_PREFIX}'"
-      exit 1
-    else
-      echo "✅ All commit messages are valid!"
-    fi
+name: "CHECK: Commit Message"
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  commit-message-check:
+    runs-on: ubuntu-latest
+
+    env:
+      ISSUE_PREFIX: ${{ vars.PROJECT_PREFIX }}
+      IGNORE_PREFIX: ${{ vars.IGNORE_PREFIX }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check commit message format
+        run: |
+          # Fetch main branch
+          git fetch origin main:main
+
+          # Check only commits not in main
+          invalid_msgs=$(
+            git log --no-merges --format="%s" main..HEAD \
+            | grep -vE "^(${IGNORE_PREFIX}|${ISSUE_PREFIX}-[0-9]+: .+)" \
+            || true
+          )
+
+          if [ -n "$invalid_msgs" ]; then
+            echo "🚨 Invalid commit message(s) detected:"
+            echo "$invalid_msgs"
+            echo "❗ Expected format: '${ISSUE_PREFIX}-<#ISSUE>: Your commit message' or start with '${IGNORE_PREFIX}'"
+            exit 1
+          else
+            echo "✅ All commit messages are valid!"
+          fi


### PR DESCRIPTION
Cleaning up githubactions. As we're enforcing 2-branch workflow, we'll be more strict with merges.

This PR fixes:
1) outdated file structure for `.github/workflows/check-commit-message.yaml`
2) Fixes actions doc `.github/workflows/WORKFLOWS_GUIDE.md`

