### PR TITLE
EFSA-112: minimap maps to all refs, not only selected main

### DIFF
--- a/modules/validation/validation-pkg/tests/test_interfile_genome_characterization.py
+++ b/modules/validation/validation-pkg/tests/test_interfile_genome_characterization.py
@@ -10,6 +10,7 @@ Tests cover:
 - Correct sequence content in output files
 - PAF best-hit selection (multi-hit queries, ribosomal RNA scenario)
 - Orientation tracking ('+' and '-' strand)
+- Ref plasmid files included in minimap2 command
 """
 
 import pytest
@@ -443,3 +444,81 @@ class TestOrientationHandling:
         )
         written_seq = str(SeqIO.read(chr1_file, "fasta").seq)
         assert written_seq == known_seq
+
+
+# ---------------------------------------------------------------------------
+# Ref plasmid files included in minimap2 command
+# ---------------------------------------------------------------------------
+
+class TestRefPlasmidFilesInMinimap2:
+    """Ref plasmid files (from plasmids_to_one=True processing) must be
+    passed to minimap2 so mod sequences homologous to non-main ref
+    chromosomes are not mis-classified as plasmids."""
+
+    @pytest.fixture
+    def setup(self, tmp_path):
+        ref_path = tmp_path / "ref.fasta"
+        plasmid_path = tmp_path / "ref_plasmid.fasta"
+        mod_path = tmp_path / "mod.fasta"
+
+        _write_fasta(ref_path, _make_records(["ref_chr"]))
+        _write_fasta(plasmid_path, _make_records(["ref_plasmid"]))
+        _write_fasta(mod_path, _make_records(["chr", "chr1", "chr2"]))
+
+        ref_result = GenomeOutputMetadata(
+            output_file=str(ref_path),
+            output_filename="ref.fasta",
+            num_sequences=1,
+            plasmid_filenames=["ref_plasmid.fasta"],
+        )
+        mod_result = GenomeOutputMetadata(
+            output_file=str(mod_path),
+            output_filename="mod.fasta",
+            num_sequences=3,
+        )
+        settings = GenomeXGenomeSettings(same_number_of_sequences=False, characterize=True)
+        return tmp_path, ref_result, mod_result, settings
+
+    def test_plasmid_file_appended_to_minimap2_command(self, setup):
+        """minimap2 receives both the main ref file and the plasmid file."""
+        tmp_path, ref_result, mod_result, settings = setup
+        paf = "\n".join([_make_paf_line("chr"), _make_paf_line("chr1"), _make_paf_line("chr2")])
+
+        with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
+             patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout=paf, returncode=0)
+            genomexgenome_validation(ref_result, mod_result, settings)
+
+        cmd = mock_run.call_args[0][0]
+        assert str(tmp_path / "ref.fasta") in cmd
+        assert str(tmp_path / "ref_plasmid.fasta") in cmd
+
+    def test_missing_plasmid_file_skipped_gracefully(self, setup):
+        """A plasmid filename that doesn't exist on disk is silently skipped."""
+        tmp_path, ref_result, mod_result, settings = setup
+        ref_result.plasmid_filenames = ["nonexistent_plasmid.fasta"]
+        paf = _make_paf_line("chr")
+
+        with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
+             patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout=paf, returncode=0)
+            result = genomexgenome_validation(ref_result, mod_result, settings)
+
+        cmd = mock_run.call_args[0][0]
+        assert "nonexistent_plasmid.fasta" not in " ".join(cmd)
+        assert result["passed"] is True
+
+    def test_no_plasmid_filenames_uses_only_main_ref(self, setup):
+        """When ref has no plasmid files, only the main ref is passed to minimap2."""
+        tmp_path, ref_result, mod_result, settings = setup
+        ref_result.plasmid_filenames = []
+        paf = _make_paf_line("chr")
+
+        with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
+             patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout=paf, returncode=0)
+            genomexgenome_validation(ref_result, mod_result, settings)
+
+        cmd = mock_run.call_args[0][0]
+        ref_files_in_cmd = [c for c in cmd if c.endswith(".fasta") and "mod" not in c]
+        assert ref_files_in_cmd == [str(tmp_path / "ref.fasta")]

--- a/modules/validation/validation-pkg/validation_pkg/validators/interfile_genome.py
+++ b/modules/validation/validation-pkg/validation_pkg/validators/interfile_genome.py
@@ -201,7 +201,7 @@ def _parse_paf_best_hits(paf_output: str) -> Dict[str, Dict]:
     Returns
     -------
     Dict mapping query_name -> {
-        'ref_name'     : str,   # name of best-matching reference sequence (expected to be only one reference = should be same all the time)
+        'ref_name'     : str,   # name of best-matching reference sequence (may come from main ref or a plasmid file)
         'strand'       : str,   # '+' or '-'
         'alignment_len': int,   # alignment block length of the winning hit
     }
@@ -268,10 +268,21 @@ def _characterize_into_metadata(ref_genome_result, mod_genome_result, metadata, 
     mod_path = _get_metadata_field(mod_genome_result, 'output_file')
     mod_filename = _get_metadata_field(mod_genome_result, 'output_filename')
 
-    logger.debug(f"Running minimap2: ref={ref_path} query={mod_path}")
+    # Include ref plasmid files so mod sequences corresponding to non-main
+    # reference chromosomes are not mis-classified as plasmids.
+    ref_plasmid_filenames = _get_metadata_field(ref_genome_result, 'plasmid_filenames') or []
+    ref_dir = Path(ref_path).parent
+    ref_files = [str(ref_path)]
+    for pf in ref_plasmid_filenames:
+        full_path = ref_dir / pf
+        if full_path.exists():
+            ref_files.append(str(full_path))
+            logger.debug(f"Including ref plasmid file in minimap2: {full_path.name}")
+
+    logger.debug(f"Running minimap2: ref={ref_files} query={mod_path}")
     try:
         proc = subprocess.run(
-            ['minimap2', '-x', 'asm5', str(ref_path), str(mod_path)],
+            ['minimap2', '-x', 'asm5'] + ref_files + [str(mod_path)],
             capture_output=True,
             text=True,
             check=True


### PR DESCRIPTION
Missing contig files. My theory:

i map mod sequences only to main selected sequence from ref, not to all sequences -> that may not math some sequences and results in flushing more sequences into plasmid file. Solution is to map to all reference sequences, but is that correct? 