### PR TITLE
EFSA-135: minimap algn concat

### DIFF
--- a/modules/validation/main.py
+++ b/modules/validation/main.py
@@ -49,8 +49,8 @@ def main():
 
     # Settings for reference genome
     ref_genome_settings = GenomeValidator.Settings(
-        plasmids_to_one=True,
-        main_longest=True,
+        plasmids_to_one=False,
+        error_n_sequences=5,
         coding_type=None,
         output_filename_suffix='ref',
         replace_id_with_incremental='chr',
@@ -103,7 +103,12 @@ def main():
     genomexgenome_settings = GenomeXGenomeSettings(
         characterize=True,
         same_sequence_ids=False,
-        same_number_of_sequences=False
+        same_number_of_sequences=False,
+        concatenate=True,
+        min_mapping_quality=0,
+        min_identity=0,
+        min_query_coverage=0,
+        max_ref_overlap=1000000,
     )
 
     # Inter read validation settings (using defaults)

--- a/modules/validation/validation-pkg/tests/test_interfile_genome_characterization.py
+++ b/modules/validation/validation-pkg/tests/test_interfile_genome_characterization.py
@@ -23,6 +23,7 @@ from validation_pkg.validators.interfile_genome import (
     GenomeXGenomeSettings,
     genomexgenome_validation,
     _parse_paf_best_hits,
+    _filter_and_group_hits,
 )
 from validation_pkg.validators.genome_validator import GenomeOutputMetadata
 from validation_pkg.exceptions import InterFileValidationError
@@ -31,6 +32,15 @@ from validation_pkg.exceptions import InterFileValidationError
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _mock_minimap2(paf_content: str):
+    """Return a side_effect for subprocess.run that writes PAF content to the stdout file."""
+    def side_effect(cmd, stdout=None, **kwargs):
+        if stdout is not None and hasattr(stdout, 'write'):
+            stdout.write(paf_content)
+        return MagicMock(returncode=0)
+    return side_effect
+
 
 def _make_records(names):
     """Create simple SeqRecord objects."""
@@ -56,11 +66,18 @@ def _make_paf_line(
     alignment_len: int = 100,
     q_start: int = 0,
     r_start: int = 0,
+    q_len: int = None,
+    r_end: int = None,
+    residue_matches: int = None,
+    mapq: int = 255,
 ) -> str:
     """Build a minimal valid PAF line (12 tab-separated columns)."""
+    q_len = q_len if q_len is not None else alignment_len
+    r_end = r_end if r_end is not None else r_start + alignment_len
+    residue_matches = residue_matches if residue_matches is not None else alignment_len
     return (
-        f"{query_id}\t{alignment_len}\t{q_start}\t{q_start + alignment_len}\t{strand}\t"
-        f"{ref_name}\t1000000\t{r_start}\t{r_start + alignment_len}\t{alignment_len}\t{alignment_len}\t255"
+        f"{query_id}\t{q_len}\t{q_start}\t{q_start + alignment_len}\t{strand}\t"
+        f"{ref_name}\t1000000\t{r_start}\t{r_end}\t{residue_matches}\t{alignment_len}\t{mapq}"
     )
 
 
@@ -123,7 +140,7 @@ class TestCharacterizationInGenomeXGenome:
 
         with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
              patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(stdout=paf, returncode=0)
+            mock_run.side_effect = _mock_minimap2(paf)
             result = genomexgenome_validation(ref_result, mod_result, settings)
 
         assert result["passed"] is True
@@ -146,7 +163,7 @@ class TestCharacterizationInGenomeXGenome:
 
         with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
              patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(stdout=paf, returncode=0)
+            mock_run.side_effect = _mock_minimap2(paf)
             result = genomexgenome_validation(ref_result, mod_result, settings)
 
         assert result["metadata"]["contigs_found"] == 3
@@ -162,7 +179,7 @@ class TestCharacterizationInGenomeXGenome:
 
         with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
              patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(stdout="", returncode=0)
+            mock_run.side_effect = _mock_minimap2("")
             result = genomexgenome_validation(ref_result, mod_result, settings)
 
         assert result["metadata"]["contigs_found"] == 0
@@ -223,7 +240,7 @@ class TestCharacterizationInGenomeXGenome:
 
         with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
              patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(stdout=paf, returncode=0)
+            mock_run.side_effect = _mock_minimap2(paf)
             result = genomexgenome_validation(ref_result, mod_result, settings)
 
         for contig_file in result["metadata"]["contig_files"]:
@@ -244,34 +261,39 @@ class TestParsePafBestHits:
     def test_single_hit_forward(self):
         paf = _make_paf_line("chr1", strand="+", ref_name="ref1", alignment_len=500)
         hits = _parse_paf_best_hits(paf)
-        assert hits["chr1"] == {"ref_name": "ref1", "strand": "+", "alignment_len": 500}
+        assert "ref1" in hits["chr1"]
+        assert hits["chr1"]["ref1"]["strand"] == "+"
+        assert hits["chr1"]["ref1"]["alignment_len"] == 500
 
     def test_single_hit_reverse(self):
         paf = _make_paf_line("chr1", strand="-", ref_name="ref1", alignment_len=500)
         hits = _parse_paf_best_hits(paf)
-        assert hits["chr1"]["strand"] == "-"
+        assert hits["chr1"]["ref1"]["strand"] == "-"
 
-    def test_best_hit_selected_by_alignment_len(self):
-        """When a query has multiple hits, the one with the largest alignment_len wins."""
+    def test_all_ref_hits_kept_per_query(self):
+        """When a query maps to multiple refs, all (query, ref) pairs are kept."""
         lines = [
             _make_paf_line("chr1", strand="+", ref_name="ref_small", alignment_len=200),
             _make_paf_line("chr1", strand="-", ref_name="ref_large", alignment_len=5000),
             _make_paf_line("chr1", strand="+", ref_name="ref_mid",   alignment_len=1000),
         ]
         hits = _parse_paf_best_hits("\n".join(lines))
-        assert hits["chr1"]["ref_name"] == "ref_large"
-        assert hits["chr1"]["strand"] == "-"
-        assert hits["chr1"]["alignment_len"] == 5000
+        # All three refs are retained as separate entries
+        assert set(hits["chr1"].keys()) == {"ref_small", "ref_large", "ref_mid"}
+        assert hits["chr1"]["ref_small"]["alignment_len"] == 200
+        assert hits["chr1"]["ref_large"]["alignment_len"] == 5000
+        assert hits["chr1"]["ref_large"]["strand"] == "-"
+        assert hits["chr1"]["ref_mid"]["alignment_len"] == 1000
 
-    def test_ribosomal_rna_many_small_hits(self):
-        """Multiple ~6k ribosomal hits: only the largest alignment survives."""
+    def test_ribosomal_rna_all_ref_hits_kept(self):
+        """Multiple ribosomal hits: all unique ref names produce separate entries."""
         rrna_hits = [
             _make_paf_line("rRNA_contig", strand="+", ref_name=f"rrna_copy_{i}", alignment_len=5900 + i)
             for i in range(5)
         ]
         hits = _parse_paf_best_hits("\n".join(rrna_hits))
-        assert hits["rRNA_contig"]["ref_name"] == "rrna_copy_4"
-        assert hits["rRNA_contig"]["alignment_len"] == 5904
+        assert set(hits["rRNA_contig"].keys()) == {f"rrna_copy_{i}" for i in range(5)}
+        assert hits["rRNA_contig"]["rrna_copy_4"]["alignment_len"] == 5904
 
     def test_multiple_queries_independent(self):
         lines = [
@@ -279,8 +301,8 @@ class TestParsePafBestHits:
             _make_paf_line("chr2", strand="-", ref_name="ref2", alignment_len=2000),
         ]
         hits = _parse_paf_best_hits("\n".join(lines))
-        assert hits["chr1"]["strand"] == "+"
-        assert hits["chr2"]["strand"] == "-"
+        assert hits["chr1"]["ref1"]["strand"] == "+"
+        assert hits["chr2"]["ref2"]["strand"] == "-"
 
     def test_empty_output(self):
         assert _parse_paf_best_hits("") == {}
@@ -289,42 +311,24 @@ class TestParsePafBestHits:
         """Lines with fewer than 12 columns are ignored."""
         assert _parse_paf_best_hits("chr1\t100\t0\t100\t+\tref1") == {}
 
-    def test_duplicate_pair_same_starts_ok(self):
-        """Same (query, ref) pair with identical q_start and r_start should not raise."""
+    def test_duplicate_pair_best_alignment_kept(self):
+        """Same (query, ref) pair: only the hit with the larger alignment_len is kept."""
         lines = [
             _make_paf_line("chr1", ref_name="ref1", alignment_len=100, q_start=0, r_start=0),
             _make_paf_line("chr1", ref_name="ref1", alignment_len=200, q_start=0, r_start=0),
         ]
         hits = _parse_paf_best_hits("\n".join(lines))
-        assert hits["chr1"]["alignment_len"] == 200
+        assert hits["chr1"]["ref1"]["alignment_len"] == 200
 
-    # def test_conflicting_q_start_raises(self):
-    #     """Same (query, ref) pair with different q_start values must raise."""
-    #     lines = [
-    #         _make_paf_line("chr1", ref_name="ref1", q_start=0, r_start=0),
-    #         _make_paf_line("chr1", ref_name="ref1", q_start=500, r_start=0),
-    #     ]
-    #     with pytest.raises(InterFileValidationError, match="q_start"):
-    #         _parse_paf_best_hits("\n".join(lines))
-
-    # def test_conflicting_r_start_raises(self):
-    #     """Same (query, ref) pair with different r_start values must raise."""
-    #     lines = [
-    #         _make_paf_line("chr1", ref_name="ref1", q_start=0, r_start=0),
-    #         _make_paf_line("chr1", ref_name="ref1", q_start=0, r_start=1000),
-    #     ]
-    #     with pytest.raises(InterFileValidationError, match="r_start"):
-    #         _parse_paf_best_hits("\n".join(lines))
-
-    def test_different_ref_names_not_conflicting(self):
-        """Same query mapping to two different refs with different starts should not raise."""
+    def test_different_ref_names_both_kept(self):
+        """Same query mapping to two different refs: both entries are retained."""
         lines = [
             _make_paf_line("chr1", ref_name="ref1", q_start=0,   r_start=0),
             _make_paf_line("chr1", ref_name="ref2", q_start=500, r_start=999),
         ]
         hits = _parse_paf_best_hits("\n".join(lines))
-        # Best hit is the one with larger alignment_len (both default to 100, so first wins)
-        assert hits["chr1"] is not None
+        assert "ref1" in hits["chr1"]
+        assert "ref2" in hits["chr1"]
 
 
 # ---------------------------------------------------------------------------
@@ -354,17 +358,18 @@ class TestOrientationHandling:
     def test_orientation_stored_in_metadata(self, fasta_setup):
         tmp_path, ref_result, mod_result, settings = fasta_setup
         paf = "\n".join([
-            _make_paf_line("chr1", strand="+"),
-            _make_paf_line("chr2", strand="-"),
+            _make_paf_line("chr1", strand="+", ref_name="ref_chr1"),
+            _make_paf_line("chr2", strand="-", ref_name="ref_chr2"),
         ])
         with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
              patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(stdout=paf, returncode=0)
+            mock_run.side_effect = _mock_minimap2(paf)
             result = genomexgenome_validation(ref_result, mod_result, settings)
 
         orientations = result["metadata"]["contig_orientations"]
-        assert orientations["chr1"] == "+"
-        assert orientations["chr2"] == "-"
+        # Individual contig entries are keyed by (query_name, ref_name) tuple
+        assert orientations[("chr1", "ref_chr1")] == "+"
+        assert orientations[("chr2", "ref_chr2")] == "-"
 
     def test_ref_names_stored_in_metadata(self, fasta_setup):
         tmp_path, ref_result, mod_result, settings = fasta_setup
@@ -374,12 +379,13 @@ class TestOrientationHandling:
         ])
         with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
              patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(stdout=paf, returncode=0)
+            mock_run.side_effect = _mock_minimap2(paf)
             result = genomexgenome_validation(ref_result, mod_result, settings)
 
         ref_names = result["metadata"]["contig_ref_names"]
-        assert ref_names["chr1"] == "ref_chr1"
-        assert ref_names["chr2"] == "ref_chr2"
+        # Individual contig entries are keyed by (query_name, ref_name) tuple
+        assert ref_names[("chr1", "ref_chr1")] == "ref_chr1"
+        assert ref_names[("chr2", "ref_chr2")] == "ref_chr2"
 
     def test_reverse_strand_sequence_is_reverse_complemented(self, fasta_setup):
         """A contig with '-' strand should be written as its reverse complement."""
@@ -405,7 +411,7 @@ class TestOrientationHandling:
         ])
         with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
              patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(stdout=paf, returncode=0)
+            mock_run.side_effect = _mock_minimap2(paf)
             result = genomexgenome_validation(ref_result, mod_result, settings)
 
         # Find the contig file for chr2 (id is renamed to 'chr' after digit-stripping)
@@ -434,7 +440,7 @@ class TestOrientationHandling:
         ])
         with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
              patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(stdout=paf, returncode=0)
+            mock_run.side_effect = _mock_minimap2(paf)
             result = genomexgenome_validation(ref_result, mod_result, settings)
 
         chr1_file = next(
@@ -443,3 +449,402 @@ class TestOrientationHandling:
         )
         written_seq = str(SeqIO.read(chr1_file, "fasta").seq)
         assert written_seq == known_seq
+
+
+
+# ---------------------------------------------------------------------------
+# Ref plasmid files included in minimap2 command
+# ---------------------------------------------------------------------------
+
+class TestRefPlasmidFilesInMinimap2:
+    """Ref plasmid files (from plasmids_to_one=True processing) must be
+    passed to minimap2 so mod sequences homologous to non-main ref
+    chromosomes are not mis-classified as plasmids."""
+
+    @pytest.fixture
+    def setup(self, tmp_path):
+        ref_path = tmp_path / "ref.fasta"
+        plasmid_path = tmp_path / "ref_plasmid.fasta"
+        mod_path = tmp_path / "mod.fasta"
+
+        _write_fasta(ref_path, _make_records(["ref_chr"]))
+        _write_fasta(plasmid_path, _make_records(["ref_plasmid"]))
+        _write_fasta(mod_path, _make_records(["chr", "chr1", "chr2"]))
+
+        ref_result = GenomeOutputMetadata(
+            output_file=str(ref_path),
+            output_filename="ref.fasta",
+            num_sequences=1,
+            plasmid_filenames=["ref_plasmid.fasta"],
+        )
+        mod_result = GenomeOutputMetadata(
+            output_file=str(mod_path),
+            output_filename="mod.fasta",
+            num_sequences=3,
+        )
+        settings = GenomeXGenomeSettings(same_number_of_sequences=False, characterize=True)
+        return tmp_path, ref_result, mod_result, settings
+
+    def test_plasmid_file_appended_to_minimap2_command(self, setup):
+        """minimap2 receives both the main ref file and the plasmid file."""
+        tmp_path, ref_result, mod_result, settings = setup
+        paf = "\n".join([_make_paf_line("chr"), _make_paf_line("chr1"), _make_paf_line("chr2")])
+
+        with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
+             patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
+            mock_run.side_effect = _mock_minimap2(paf)
+            genomexgenome_validation(ref_result, mod_result, settings)
+
+        cmd = mock_run.call_args[0][0]
+        assert str(tmp_path / "ref.fasta") in cmd
+        assert str(tmp_path / "ref_plasmid.fasta") in cmd
+
+    def test_missing_plasmid_file_skipped_gracefully(self, setup):
+        """A plasmid filename that doesn't exist on disk is silently skipped."""
+        tmp_path, ref_result, mod_result, settings = setup
+        ref_result.plasmid_filenames = ["nonexistent_plasmid.fasta"]
+        paf = _make_paf_line("chr")
+
+        with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
+             patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
+            mock_run.side_effect = _mock_minimap2(paf)
+            result = genomexgenome_validation(ref_result, mod_result, settings)
+
+        cmd = mock_run.call_args[0][0]
+        assert "nonexistent_plasmid.fasta" not in " ".join(cmd)
+        assert result["passed"] is True
+
+    def test_no_plasmid_filenames_uses_only_main_ref(self, setup):
+        """When ref has no plasmid files, only the main ref is passed to minimap2."""
+        tmp_path, ref_result, mod_result, settings = setup
+        ref_result.plasmid_filenames = []
+        paf = _make_paf_line("chr")
+
+        with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
+             patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
+            mock_run.side_effect = _mock_minimap2(paf)
+            genomexgenome_validation(ref_result, mod_result, settings)
+
+        cmd = mock_run.call_args[0][0]
+        ref_files_in_cmd = [c for c in cmd if c.endswith(".fasta") and "mod" not in c]
+        assert ref_files_in_cmd == [str(tmp_path / "ref.fasta")]
+
+
+# ---------------------------------------------------------------------------
+# Settings tests for concatenation
+# ---------------------------------------------------------------------------
+
+class TestGenomeXGenomeSettingsConcatenate:
+
+    def test_concatenate_default_false(self):
+        assert GenomeXGenomeSettings().concatenate is False
+
+    def test_concatenate_enabled(self):
+        assert GenomeXGenomeSettings(concatenate=True).concatenate is True
+
+    def test_min_query_coverage_invalid_raises(self):
+        with pytest.raises(Exception, match="min_query_coverage"):
+            GenomeXGenomeSettings(min_query_coverage=1.5)
+
+    def test_min_query_coverage_negative_raises(self):
+        with pytest.raises(Exception, match="min_query_coverage"):
+            GenomeXGenomeSettings(min_query_coverage=-0.1)
+
+    def test_min_identity_invalid_raises(self):
+        with pytest.raises(Exception, match="min_identity"):
+            GenomeXGenomeSettings(min_identity=2.0)
+
+    def test_min_mapping_quality_negative_raises(self):
+        with pytest.raises(Exception, match="min_mapping_quality"):
+            GenomeXGenomeSettings(min_mapping_quality=-1)
+
+    def test_max_ref_overlap_negative_raises(self):
+        with pytest.raises(Exception, match="max_ref_overlap"):
+            GenomeXGenomeSettings(max_ref_overlap=-1)
+
+    def test_settings_roundtrip(self):
+        s = GenomeXGenomeSettings(concatenate=True, min_query_coverage=0.8, min_identity=0.95)
+        d = s.to_dict()
+        s2 = GenomeXGenomeSettings.from_dict(d)
+        assert s2.concatenate is True
+        assert s2.min_query_coverage == 0.8
+        assert s2.min_identity == 0.95
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _filter_and_group_hits
+# ---------------------------------------------------------------------------
+
+class TestFilterAndGroupHits:
+
+    def _make_logger(self):
+        import logging
+        return logging.getLogger("test")
+
+    def _hit(self, strand="+", alignment_len=1000,
+              q_len=1000, r_start=0, r_end=1000, residue_matches=1000, mapq=60):
+        """Return a single hit dict (ref_name is now the key, not a field)."""
+        return {
+            'strand': strand,
+            'alignment_len': alignment_len, 'q_len': q_len,
+            'q_end': alignment_len, 'r_start': r_start, 'r_end': r_end,
+            'residue_matches': residue_matches, 'mapq': mapq,
+        }
+
+    def test_single_hit_passes(self):
+        hits = {"ctg1": {"chrX": self._hit()}}
+        settings = GenomeXGenomeSettings(concatenate=True)
+        groups, individual_ids = _filter_and_group_hits(hits, settings, self._make_logger())
+        assert "chrX" in groups
+        assert groups["chrX"] == ["ctg1"]
+        assert individual_ids == set()
+
+    def test_mapq_below_threshold_goes_individual(self):
+        hits = {"ctg1": {"chrX": self._hit(mapq=5)}}
+        settings = GenomeXGenomeSettings(concatenate=True, min_mapping_quality=10)
+        groups, individual_ids = _filter_and_group_hits(hits, settings, self._make_logger())
+        assert groups == {}
+        assert ("ctg1", "chrX") in individual_ids
+
+    def test_query_coverage_below_threshold_goes_individual(self):
+        # alignment_len=400, q_len=1000 → coverage=0.4 < 0.5
+        hits = {"ctg1": {"chrX": self._hit(alignment_len=400, q_len=1000)}}
+        settings = GenomeXGenomeSettings(concatenate=True, min_query_coverage=0.5)
+        groups, individual_ids = _filter_and_group_hits(hits, settings, self._make_logger())
+        assert groups == {}
+        assert ("ctg1", "chrX") in individual_ids
+
+    def test_identity_below_threshold_goes_individual(self):
+        # residue_matches=800, alignment_len=1000 → identity=0.8 < 0.9
+        hits = {"ctg1": {"chrX": self._hit(residue_matches=800, alignment_len=1000)}}
+        settings = GenomeXGenomeSettings(concatenate=True, min_identity=0.9)
+        groups, individual_ids = _filter_and_group_hits(hits, settings, self._make_logger())
+        assert groups == {}
+        assert ("ctg1", "chrX") in individual_ids
+
+    def test_multiple_queries_same_ref_grouped_sorted_by_r_start(self):
+        hits = {
+            "ctg_b": {"chr1": self._hit(r_start=5000, r_end=9000)},
+            "ctg_a": {"chr1": self._hit(r_start=0,    r_end=4000)},
+            "ctg_c": {"chr1": self._hit(r_start=9500, r_end=13000)},
+        }
+        settings = GenomeXGenomeSettings(concatenate=True)
+        groups, individual_ids = _filter_and_group_hits(hits, settings, self._make_logger())
+        assert groups["chr1"] == ["ctg_a", "ctg_b", "ctg_c"]
+        assert individual_ids == set()
+
+    def test_different_refs_form_separate_groups(self):
+        hits = {
+            "ctg1": {"chr1": self._hit()},
+            "ctg2": {"chr2": self._hit()},
+        }
+        settings = GenomeXGenomeSettings(concatenate=True)
+        groups, individual_ids = _filter_and_group_hits(hits, settings, self._make_logger())
+        assert set(groups.keys()) == {"chr1", "chr2"}
+        assert individual_ids == set()
+
+    def test_overlap_exceeds_max_demotes_entire_group(self):
+        # ctg_a ends at 1000, ctg_b starts at 800 → overlap=200 > max_ref_overlap=0
+        hits = {
+            "ctg_a": {"chr1": self._hit(r_start=0,   r_end=1000)},
+            "ctg_b": {"chr1": self._hit(r_start=800, r_end=2000)},
+        }
+        settings = GenomeXGenomeSettings(concatenate=True, max_ref_overlap=0)
+        groups, individual_ids = _filter_and_group_hits(hits, settings, self._make_logger())
+        assert groups == {}
+        assert {("ctg_a", "chr1"), ("ctg_b", "chr1")} == individual_ids
+
+    def test_overlap_within_max_passes(self):
+        # overlap=100, max_ref_overlap=200 → passes
+        hits = {
+            "ctg_a": {"chr1": self._hit(r_start=0,   r_end=1000)},
+            "ctg_b": {"chr1": self._hit(r_start=900, r_end=2000)},
+        }
+        settings = GenomeXGenomeSettings(concatenate=True, max_ref_overlap=200)
+        groups, individual_ids = _filter_and_group_hits(hits, settings, self._make_logger())
+        assert "chr1" in groups
+        assert individual_ids == set()
+
+    def test_overlap_in_one_group_does_not_affect_other(self):
+        hits = {
+            "bad_a": {"chr1": self._hit(r_start=0,   r_end=1000)},
+            "bad_b": {"chr1": self._hit(r_start=500, r_end=2000)},
+            "good":  {"chr2": self._hit(r_start=0,   r_end=1000)},
+        }
+        settings = GenomeXGenomeSettings(concatenate=True, max_ref_overlap=0)
+        groups, individual_ids = _filter_and_group_hits(hits, settings, self._make_logger())
+        assert "chr1" not in groups
+        assert "chr2" in groups
+        assert {("bad_a", "chr1"), ("bad_b", "chr1")} == individual_ids
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for concatenation mode
+# ---------------------------------------------------------------------------
+
+class TestConcatenateMode:
+
+    @pytest.fixture
+    def setup(self, tmp_path):
+        # 4 mod sequences: ctg_a + ctg_b → chr1, ctg_c → chr2, plasmid stays unmapped
+        ref_seqs = _make_records(["chr1", "chr2"])
+        mod_seqs = [
+            SeqRecord(Seq("AAAA" * 25), id="ctg_a", description=""),
+            SeqRecord(Seq("CCCC" * 25), id="ctg_b", description=""),
+            SeqRecord(Seq("GGGG" * 25), id="ctg_c", description=""),
+            SeqRecord(Seq("TTTT" * 25), id="plasmid1", description=""),
+        ]
+        ref_path = tmp_path / "ref.fasta"
+        mod_path = tmp_path / "mod.fasta"
+        _write_fasta(ref_path, ref_seqs)
+        _write_fasta(mod_path, mod_seqs)
+
+        ref_result = GenomeOutputMetadata(
+            output_file=str(ref_path), output_filename="ref.fasta", num_sequences=2,
+        )
+        mod_result = GenomeOutputMetadata(
+            output_file=str(mod_path), output_filename="mod.fasta", num_sequences=4,
+        )
+        return tmp_path, ref_result, mod_result
+
+    def _run(self, ref_result, mod_result, paf, **setting_kwargs):
+        settings = GenomeXGenomeSettings(
+            same_number_of_sequences=False, characterize=True,
+            concatenate=True, **setting_kwargs
+        )
+        with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
+             patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
+            mock_run.side_effect = _mock_minimap2(paf)
+            return genomexgenome_validation(ref_result, mod_result, settings)
+
+    def test_two_queries_same_ref_produce_one_contig_file(self, setup):
+        tmp_path, ref_result, mod_result = setup
+        paf = "\n".join([
+            _make_paf_line("ctg_a", ref_name="chr1", r_start=0,    r_end=100, alignment_len=100),
+            _make_paf_line("ctg_b", ref_name="chr1", r_start=100,  r_end=200, alignment_len=100),
+            _make_paf_line("ctg_c", ref_name="chr2", r_start=0,    r_end=100, alignment_len=100),
+        ])
+        result = self._run(ref_result, mod_result, paf)
+        meta = result["metadata"]
+        # chr1 group → 1 file, chr2 individual → 1 file = 2 contig files total
+        assert len(meta["contig_files"]) == 2
+        assert meta["plasmids_found"] == 1
+        assert meta["concat_groups"] is not None
+        assert "chr1" in meta["concat_groups"]
+        assert meta["concat_groups"]["chr1"]["query_names"] == ["ctg_a", "ctg_b"]
+
+    def test_concat_sequence_is_in_r_start_order(self, setup):
+        tmp_path, ref_result, mod_result = setup
+        # ctg_b maps earlier on ref (r_start=0), ctg_a maps later (r_start=100)
+        paf = "\n".join([
+            _make_paf_line("ctg_a", ref_name="chr1", r_start=100, r_end=200, alignment_len=100),
+            _make_paf_line("ctg_b", ref_name="chr1", r_start=0,   r_end=100, alignment_len=100),
+            _make_paf_line("ctg_c", ref_name="chr2", r_start=0,   r_end=100, alignment_len=100),
+        ])
+        result = self._run(ref_result, mod_result, paf)
+        meta = result["metadata"]
+        # ctg_b (r_start=0) should come before ctg_a (r_start=100)
+        assert meta["concat_groups"]["chr1"]["query_names"] == ["ctg_b", "ctg_a"]
+
+    def test_concat_file_contains_merged_sequence(self, setup):
+        tmp_path, ref_result, mod_result = setup
+        paf = "\n".join([
+            _make_paf_line("ctg_a", ref_name="chr1", r_start=0,   r_end=100, alignment_len=100),
+            _make_paf_line("ctg_b", ref_name="chr1", r_start=100, r_end=200, alignment_len=100),
+            _make_paf_line("ctg_c", ref_name="chr2", r_start=0,   r_end=100, alignment_len=100),
+        ])
+        result = self._run(ref_result, mod_result, paf)
+        chr1_file = result["metadata"]["concat_groups"]["chr1"]["contig_file"]
+        records = list(SeqIO.parse(chr1_file, "fasta"))
+        assert len(records) == 1
+        # ctg_a = AAAA*25 (100bp), ctg_b = CCCC*25 (100bp) → 200bp total
+        assert len(records[0].seq) == 200
+
+    def test_query_failing_threshold_written_individually(self, setup):
+        tmp_path, ref_result, mod_result = setup
+        # ctg_a has low MAPQ → falls back to individual file; ctg_b alone on chr1
+        paf = "\n".join([
+            _make_paf_line("ctg_a", ref_name="chr1", r_start=0,   r_end=100,
+                           alignment_len=100, mapq=2),
+            _make_paf_line("ctg_b", ref_name="chr1", r_start=100, r_end=200,
+                           alignment_len=100, mapq=60),
+            _make_paf_line("ctg_c", ref_name="chr2", r_start=0,   r_end=100,
+                           alignment_len=100, mapq=60),
+        ])
+        result = self._run(ref_result, mod_result, paf, min_mapping_quality=10)
+        meta = result["metadata"]
+        # chr1 group has only ctg_b (ctg_a failed), chr2 has ctg_c → 2 concat groups
+        # ctg_a written individually → 1 extra file
+        # total = 2 + 1 = 3 contig files
+        assert len(meta["contig_files"]) == 3
+
+    def test_overlapping_group_written_individually(self, setup):
+        tmp_path, ref_result, mod_result = setup
+        # ctg_a and ctg_b overlap on chr1 → both written individually
+        paf = "\n".join([
+            _make_paf_line("ctg_a", ref_name="chr1", r_start=0,   r_end=150, alignment_len=100),
+            _make_paf_line("ctg_b", ref_name="chr1", r_start=100, r_end=200, alignment_len=100),
+            _make_paf_line("ctg_c", ref_name="chr2", r_start=0,   r_end=100, alignment_len=100),
+        ])
+        result = self._run(ref_result, mod_result, paf, max_ref_overlap=0)
+        meta = result["metadata"]
+        assert "chr1" not in (meta["concat_groups"] or {})
+        # ctg_a + ctg_b individual + ctg_c individual = 3 files
+        assert len(meta["contig_files"]) == 3
+
+    def test_contig_orientations_nested_for_concat_groups(self, setup):
+        tmp_path, ref_result, mod_result = setup
+        paf = "\n".join([
+            _make_paf_line("ctg_a", strand="+", ref_name="chr1", r_start=0,   r_end=100, alignment_len=100),
+            _make_paf_line("ctg_b", strand="-", ref_name="chr1", r_start=100, r_end=200, alignment_len=100),
+            _make_paf_line("ctg_c", ref_name="chr2", r_start=0,  r_end=100, alignment_len=100),
+        ])
+        result = self._run(ref_result, mod_result, paf)
+        orientations = result["metadata"]["contig_orientations"]
+        # chr1 is a concat group → nested dict
+        assert isinstance(orientations["chr1"], dict)
+        assert orientations["chr1"]["ctg_a"] == "+"
+        assert orientations["chr1"]["ctg_b"] == "-"
+
+    def test_concatenate_false_behaves_as_before(self, setup):
+        tmp_path, ref_result, mod_result = setup
+        paf = "\n".join([
+            _make_paf_line("ctg_a", ref_name="chr1"),
+            _make_paf_line("ctg_b", ref_name="chr1"),
+            _make_paf_line("ctg_c", ref_name="chr2"),
+        ])
+        settings = GenomeXGenomeSettings(same_number_of_sequences=False, characterize=True)
+        with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
+             patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
+            mock_run.side_effect = _mock_minimap2(paf)
+            result = genomexgenome_validation(ref_result, mod_result, settings)
+        meta = result["metadata"]
+        assert len(meta["contig_files"]) == 3
+        assert meta["concat_groups"] is None
+        # In non-concat mode all entries are individual: keys are (query, ref) tuples, values are strand strings
+        assert all(isinstance(k, tuple) for k in meta["contig_orientations"].keys())
+        assert all(isinstance(v, str) for v in meta["contig_orientations"].values())
+
+    def test_query_mapping_two_refs_produces_two_contig_files(self, setup):
+        """A single query that maps to two distinct refs gets a unique contig file per ref."""
+        tmp_path, ref_result, mod_result = setup
+        paf = "\n".join([
+            # ctg_a maps to BOTH chr1 and chr2
+            _make_paf_line("ctg_a", ref_name="chr1", r_start=0,   r_end=100, alignment_len=100),
+            _make_paf_line("ctg_a", ref_name="chr2", r_start=0,   r_end=100, alignment_len=80),
+            # ctg_b maps only to chr1
+            _make_paf_line("ctg_b", ref_name="chr1", r_start=100, r_end=200, alignment_len=100),
+        ])
+        settings = GenomeXGenomeSettings(same_number_of_sequences=False, characterize=True)
+        with patch("validation_pkg.validators.interfile_genome.check_tool_available", return_value=True), \
+             patch("validation_pkg.validators.interfile_genome.subprocess.run") as mock_run:
+            mock_run.side_effect = _mock_minimap2(paf)
+            result = genomexgenome_validation(ref_result, mod_result, settings)
+
+        meta = result["metadata"]
+        # ctg_a → chr1, ctg_a → chr2, ctg_b → chr1 = 3 individual contig files
+        assert len(meta["contig_files"]) == 3
+        # Both (ctg_a, chr1) and (ctg_a, chr2) are in orientations
+        assert ("ctg_a", "chr1") in meta["contig_orientations"]
+        assert ("ctg_a", "chr2") in meta["contig_orientations"]
+        assert ("ctg_b", "chr1") in meta["contig_orientations"]

--- a/modules/validation/validation-pkg/validation_pkg/validators/interfile_genome.py
+++ b/modules/validation/validation-pkg/validation_pkg/validators/interfile_genome.py
@@ -30,6 +30,12 @@ class GenomeXGenomeSettings(BaseSettings):
     same_sequence_ids: bool = False
     same_sequence_lengths: bool = False
     characterize: bool = True
+    # Concatenation settings (used when characterize=True)
+    concatenate: bool = False
+    min_mapping_quality: int = 0      # PAF col 11; 0 = accept all
+    min_query_coverage: float = 0.0   # alignment_len / q_len; 0.0 = accept all
+    min_identity: float = 0.0         # residue_matches / alignment_len; 0.0 = accept all
+    max_ref_overlap: int = 0          # max allowed overlap (bp) between adjacent queries on ref
 
     def __post_init__(self):
         if self.same_sequence_lengths and not self.same_sequence_ids:
@@ -37,6 +43,14 @@ class GenomeXGenomeSettings(BaseSettings):
                 "same_sequence_lengths requires same_sequence_ids=True "
                 "(cannot compare lengths without matching IDs)"
             )
+        if not (0.0 <= self.min_query_coverage <= 1.0):
+            raise ValidationError("min_query_coverage must be between 0.0 and 1.0")
+        if not (0.0 <= self.min_identity <= 1.0):
+            raise ValidationError("min_identity must be between 0.0 and 1.0")
+        if self.min_mapping_quality < 0:
+            raise ValidationError("min_mapping_quality must be >= 0")
+        if self.max_ref_overlap < 0:
+            raise ValidationError("max_ref_overlap must be >= 0")
 
 
 def genomexgenome_validation(
@@ -151,7 +165,7 @@ def genomexgenome_validation(
     if settings.characterize:
         logger.info("Running genome characterization: contigs vs plasmids via minimap2")
         try:
-            _characterize_into_metadata(ref_genome_result, mod_genome_result, metadata, logger)
+            _characterize_into_metadata(ref_genome_result, mod_genome_result, metadata, logger, settings)
         except Exception as e:
             error_msg = f"Genome characterization skipped: {e}"
             errors.append(error_msg)
@@ -182,8 +196,8 @@ def genomexgenome_validation(
     return result
 
 
-def _parse_paf_best_hits(paf_path: str) -> Dict[str, Dict]:
-    """Parse a PAF file and return the best-scoring hit per query sequence.
+def _parse_paf_best_hits(paf_source: str) -> Dict[str, Dict[str, Dict]]:
+    """Parse a PAF file (or raw PAF string) and return the best-scoring hit per (query, ref) pair.
 
     PAF columns (0-indexed):
       0  query name      1  query length
@@ -193,68 +207,160 @@ def _parse_paf_best_hits(paf_path: str) -> Dict[str, Dict]:
       8  r_end           9  residue matches
       10 alignment block length   11 mapping quality
 
-    For each query name the hit with the largest alignment block length
-    (col 10) is selected.  This correctly handles multi-copy elements such
-    as ribosomal RNA that produce many hits: only the highest-scoring
-    reference assignment is kept.
+    For each (query_name, ref_name) pair the hit with the largest alignment
+    block length (col 10) is selected.  A query that maps to multiple distinct
+    reference sequences produces one entry per ref_name, enabling a unique
+    contig file to be written for every such mapping.
+
+    Parameters
+    ----------
+    paf_source : str
+        Either a file path to a PAF file, or a raw PAF string (containing newlines).
 
     Returns
     -------
-    Dict mapping query_name -> {
-        'ref_name'     : str,   # name of best-matching reference sequence (expected to be only one reference = should be same all the time)
-        'strand'       : str,   # '+' or '-'
-        'alignment_len': int,   # alignment block length of the winning hit
+    Dict mapping query_name -> ref_name -> {
+        'strand'        : str,   # '+' or '-'
+        'alignment_len' : int,   # alignment block length (col 10)
+        'q_len'         : int,   # query length (col 1)
+        'q_end'         : int,   # query alignment end (col 3)
+        'r_start'       : int,   # reference alignment start (col 7)
+        'r_end'         : int,   # reference alignment end (col 8)
+        'residue_matches': int,  # matching residues (col 9)
+        'mapq'          : int,   # mapping quality (col 11)
     }
     """
-    best_hits: Dict[str, Dict] = {}
-    # Track (q_start, r_start) per (query_name, ref_name) pair to detect ambiguous alignments
-    # pair_starts: Dict[tuple, tuple] = {}
-    with open(paf_path, 'r') as fh:
-        for line in fh:
-            if not line.strip():
-                continue
-            cols = line.split('\t')
-            if len(cols) < 12:
-                continue
-            query_name = cols[0]
-            strand = cols[4]
-            ref_name = cols[5]
-            try:
-                q_start = int(cols[2])
-                r_start = int(cols[7])
-                alignment_block_len = int(cols[10])
-            except ValueError:
-                continue
+    if '\t' in paf_source or paf_source == '':
+        lines = paf_source.splitlines()
+    else:
+        with open(paf_source, 'r') as fh:
+            lines = fh.readlines()
 
-            # pair_key = (query_name, ref_name)
-            # if pair_key in pair_starts:
-            #     seen_q_start, seen_r_start = pair_starts[pair_key]
-            #     if q_start != seen_q_start:
-            #         raise InterFileValidationError(
-            #             f"Ambiguous minimap2 alignment: query '{query_name}' maps to "
-            #             f"reference '{ref_name}' with conflicting q_start values "
-            #             f"({seen_q_start} and {q_start})"
-            #         )
-            #     if r_start != seen_r_start:
-            #         raise InterFileValidationError(
-            #             f"Ambiguous minimap2 alignment: query '{query_name}' maps to "
-            #             f"reference '{ref_name}' with conflicting r_start values "
-            #             f"({seen_r_start} and {r_start})"
-            #         )
-            # else:
-            #     pair_starts[pair_key] = (q_start, r_start)
+    best_hits: Dict[str, Dict[str, Dict]] = {}
+    for line in lines:
+        if not line.strip():
+            continue
+        cols = line.split('\t')
+        if len(cols) < 12:
+            continue
+        query_name = cols[0]
+        strand = cols[4]
+        ref_name = cols[5]
+        try:
+            alignment_block_len = int(cols[10])
+            q_len   = int(cols[1])
+            q_end   = int(cols[3])
+            r_start = int(cols[7])
+            r_end   = int(cols[8])
+            residue_matches = int(cols[9])
+            mapq    = int(cols[11])
+        except ValueError:
+            continue
 
-            current = best_hits.get(query_name)
-            if current is None or alignment_block_len > current['alignment_len']:
-                best_hits[query_name] = {
-                    'ref_name': ref_name,
-                    'strand': strand,
-                    'alignment_len': alignment_block_len,
-                }
+        ref_hits = best_hits.setdefault(query_name, {})
+        current = ref_hits.get(ref_name)
+        if current is None or alignment_block_len > current['alignment_len']:
+            ref_hits[ref_name] = {
+                'strand':          strand,
+                'alignment_len':   alignment_block_len,
+                'q_len':           q_len,
+                'q_end':           q_end,
+                'r_start':         r_start,
+                'r_end':           r_end,
+                'residue_matches': residue_matches,
+                'mapq':            mapq,
+            }
     return best_hits
 
 
-def _characterize_into_metadata(ref_genome_result, mod_genome_result, metadata, logger):
+def _filter_and_group_hits(
+    best_hits: Dict[str, Dict[str, Dict]],
+    settings: GenomeXGenomeSettings,
+    logger,
+) -> tuple:
+    """Filter PAF hits by quality thresholds and group passing queries by reference.
+
+    (query_name, ref_name) pairs failing per-hit thresholds, or belonging to a
+    group whose adjacent reference mappings overlap more than max_ref_overlap,
+    are returned in individual_ids and written as standalone contig files by
+    the caller.
+
+    Returns
+    -------
+    groups : Dict[ref_name, List[query_name]]
+        Queries that passed all checks, sorted by r_start within each group.
+    individual_ids : set[Tuple[str, str]]
+        (query_name, ref_name) pairs that failed a threshold or overlap check.
+    """
+    passed: Dict[tuple, Dict] = {}
+    individual_ids: set = set()
+
+    for query_name, ref_hits in best_hits.items():
+        for ref_name, hit in ref_hits.items():
+            if hit['mapq'] < settings.min_mapping_quality:
+                logger.debug(
+                    f"  {query_name} → {ref_name}: MAPQ {hit['mapq']} < "
+                    f"{settings.min_mapping_quality}, writing individually"
+                )
+                individual_ids.add((query_name, ref_name))
+                continue
+
+            query_coverage = hit['alignment_len'] / hit['q_len'] if hit['q_len'] > 0 else 0.0
+            if query_coverage < settings.min_query_coverage:
+                logger.debug(
+                    f"  {query_name} → {ref_name}: query_coverage {query_coverage:.3f} < "
+                    f"{settings.min_query_coverage}, writing individually"
+                )
+                individual_ids.add((query_name, ref_name))
+                continue
+
+            identity = (
+                hit['residue_matches'] / hit['alignment_len']
+                if hit['alignment_len'] > 0 else 0.0
+            )
+            if identity < settings.min_identity:
+                logger.debug(
+                    f"  {query_name} → {ref_name}: identity {identity:.3f} < "
+                    f"{settings.min_identity}, writing individually"
+                )
+                individual_ids.add((query_name, ref_name))
+                continue
+
+            passed[(query_name, ref_name)] = hit
+
+    # Group by ref_name, sort each group by r_start
+    groups: Dict[str, List] = {}
+    for (query_name, ref_name), hit in passed.items():
+        groups.setdefault(ref_name, []).append(query_name)
+    for ref_name in groups:
+        groups[ref_name].sort(key=lambda qn: passed[(qn, ref_name)]['r_start'])
+
+    # Per-group overlap check: demote entire group if any adjacent pair overlaps too much
+    clean_groups: Dict[str, List] = {}
+    for ref_name, query_names in groups.items():
+        has_overlap = False
+        for i in range(len(query_names) - 1):
+            q_a, q_b = query_names[i], query_names[i + 1]
+            overlap = max(0, passed[(q_a, ref_name)]['r_end'] - passed[(q_b, ref_name)]['r_start'])
+            if overlap > settings.max_ref_overlap:
+                logger.warning(
+                    f"Concat group for ref '{ref_name}' has reference overlap "
+                    f"{overlap} bp between '{q_a}' and '{q_b}' "
+                    f"(max_ref_overlap={settings.max_ref_overlap}). "
+                    "Writing sequences individually."
+                )
+                has_overlap = True
+                break
+        if has_overlap:
+            for qn in query_names:
+                individual_ids.add((qn, ref_name))
+        else:
+            clean_groups[ref_name] = query_names
+
+    return clean_groups, individual_ids
+
+
+def _characterize_into_metadata(ref_genome_result, mod_genome_result, metadata, logger, settings: GenomeXGenomeSettings = None):
     """Run minimap2 alignment and populate characterization keys into metadata.
 
     Raises an exception on any failure so the caller can demote it to a warning.
@@ -282,15 +388,31 @@ def _characterize_into_metadata(ref_genome_result, mod_genome_result, metadata, 
             f"minimap2 failed (exit code {e.returncode}): {e.stderr.strip()}"
         )
 
-    # Parse PAF file: for each query keep only the best-scoring hit so that
-    # multi-copy elements (e.g. ribosomal RNA) are resolved to a single
-    # reference assignment, and orientation is captured.
+    # Parse PAF file: for each (query, ref) pair keep the best-scoring hit so
+    # that a query mapping to multiple reference sequences produces one contig
+    # file per reference mapping.
     best_hits = _parse_paf_best_hits(str(paf_path))
     mapped_ids = set(best_hits.keys())
 
     logger.debug(f"minimap2 mapped {len(mapped_ids)} sequence(s) to reference")
 
-    # Split sequences into contigs (mapped) and plasmids (unmapped)
+    # Determine grouping for concatenation mode
+    if settings is not None and settings.concatenate:
+        groups, individual_ids = _filter_and_group_hits(best_hits, settings, logger)
+        concat_pairs = {(qn, ref) for ref, qns in groups.items() for qn in qns}
+        logger.debug(
+            f"Concatenation: {len(groups)} group(s), "
+            f"{len(individual_ids)} (query,ref) pair(s) written individually"
+        )
+    else:
+        groups = {}
+        concat_pairs: set = set()
+
+    # All (query_name, ref_name) pairs from best_hits
+    all_pairs = {(qn, ref) for qn, ref_hits in best_hits.items() for ref in ref_hits}
+    individual_pairs = all_pairs - concat_pairs
+
+    # Split sequences: mapped → contigs, unmapped → plasmids
     contig_seqs: List = []
     plasmid_seqs: List = []
     for record in SeqIO.parse(str(mod_path), 'fasta'):
@@ -299,10 +421,50 @@ def _characterize_into_metadata(ref_genome_result, mod_genome_result, metadata, 
         else:
             plasmid_seqs.append(record)
 
-    # Write each contig to its own file
+    seq_by_id = {seq.id: seq for seq in contig_seqs}
     contig_files: List[str] = []
-    for i, seq in enumerate(contig_seqs):
-        hit = best_hits[seq.id]
+    contig_index = 0
+    concat_groups_metadata: Dict[str, Any] = {}
+
+    # --- Concatenated groups ---
+    for ref_name, query_names in groups.items():
+        oriented_parts = []
+        for qn in query_names:
+            hit = best_hits[qn][ref_name]
+            seq = seq_by_id[qn]
+            new_id = seq.id.rstrip('0123456789')
+            if hit['strand'] == '-':
+                part = seq.reverse_complement(id=new_id, description='')
+            else:
+                part = seq[:]
+                part.id = new_id
+                part.description = ''
+            oriented_parts.append(part)
+
+        concat_seq = oriented_parts[0]
+        for part in oriented_parts[1:]:
+            concat_seq = concat_seq + part
+        concat_seq.id = ref_name.rstrip('0123456789')
+        concat_seq.description = f"concatenated_{len(query_names)}_queries"
+
+        contig_path = output_dir / f"{base_name}_contig_{contig_index}.fasta"
+        with open_compressed_writer(contig_path, CodingType.NONE) as handle:
+            SeqIO.write([concat_seq], handle, 'fasta')
+        contig_files.append(str(contig_path))
+        concat_groups_metadata[ref_name] = {
+            'query_names': query_names,
+            'contig_file': str(contig_path),
+        }
+        logger.debug(
+            f"Concat contig {contig_index}: {len(query_names)} queries → "
+            f"{ref_name} ({len(concat_seq.seq)} bp) → {contig_path.name}"
+        )
+        contig_index += 1
+
+    # --- Individual contigs: one file per (query_name, ref_name) pair ---
+    for query_name, ref_name in sorted(individual_pairs):
+        hit = best_hits[query_name][ref_name]
+        seq = seq_by_id[query_name]
         new_id = seq.id.rstrip('0123456789')
         if hit['strand'] == '-':
             out_seq = seq.reverse_complement(id=new_id, description='')
@@ -310,14 +472,15 @@ def _characterize_into_metadata(ref_genome_result, mod_genome_result, metadata, 
             out_seq = seq[:]
             out_seq.id = new_id
             out_seq.description = ''
-        contig_path = output_dir / f"{base_name}_contig_{i}.fasta"
+        contig_path = output_dir / f"{base_name}_contig_{contig_index}.fasta"
         with open_compressed_writer(contig_path, CodingType.NONE) as handle:
             SeqIO.write([out_seq], handle, 'fasta')
         contig_files.append(str(contig_path))
         logger.debug(
-            f"Contig {i}: {new_id} ({len(out_seq.seq)} bp) "
-            f"→ {hit['ref_name']} [{hit['strand']}] → {contig_path.name}"
+            f"Contig {contig_index}: {new_id} ({len(out_seq.seq)} bp) "
+            f"→ {ref_name} [{hit['strand']}] → {contig_path.name}"
         )
+        contig_index += 1
 
     # Write all plasmids to a single file
     plasmid_file: Optional[str] = None
@@ -330,14 +493,30 @@ def _characterize_into_metadata(ref_genome_result, mod_genome_result, metadata, 
 
     logger.info(
         f"Genome characterization complete: "
-        f"{len(contig_seqs)} contig(s), {len(plasmid_seqs)} plasmid(s)"
+        f"{len(contig_files)} contig file(s) "
+        f"({len(groups)} concatenated group(s), {len(individual_pairs)} individual (query,ref) pair(s)), "
+        f"{len(plasmid_seqs)} plasmid(s)"
+    )
+
+    # Build orientation/ref-name metadata: nested for groups, tuple-keyed for individual pairs
+    contig_orientations: Dict[str, Any] = {
+        ref_name: {qn: best_hits[qn][ref_name]['strand'] for qn in qns}
+        for ref_name, qns in groups.items()
+    }
+    contig_orientations.update(
+        {(qn, ref): best_hits[qn][ref]['strand'] for qn, ref in individual_pairs}
+    )
+    contig_ref_names: Dict[str, Any] = {ref_name: ref_name for ref_name in groups}
+    contig_ref_names.update(
+        {(qn, ref): ref for qn, ref in individual_pairs}
     )
 
     metadata.update({
-        'contigs_found': len(contig_seqs),
+        'contigs_found': len(contig_files),
         'plasmids_found': len(plasmid_seqs),
         'contig_files': contig_files,
         'plasmid_file': plasmid_file,
-        'contig_orientations': {seq.id: best_hits[seq.id]['strand'] for seq in contig_seqs},
-        'contig_ref_names': {seq.id: best_hits[seq.id]['ref_name'] for seq in contig_seqs},
+        'contig_orientations': contig_orientations,
+        'contig_ref_names': contig_ref_names,
+        'concat_groups': concat_groups_metadata or None,
     })


### PR DESCRIPTION
Request: When multiple query sequences match the same reference, then concatenate the sequences to one _contig file.

Implementation:
- Adding multiple sequence reference fasta into minimap (old code mapped only to the longest sequence form all)
- while parsing, every mapping reference sequence is saved into its own _contig_file.
- all of the query sequences matching one reference sequence are concatenated and saved into _contig file.
- non-matching sequences from both mod and ref are stored in mod_plasmid and ref_plasmid files.
- parameters for contig concatenation are included, but not fine-tuned:
    min_mapping_quality: int = 0      # PAF col 11; 0 = accept all
    min_query_coverage: float = 0.0   # alignment_len / q_len; 0.0 = accept all
    min_identity: float = 0.0         # residue_matches / alignment_len; 0.0 = accept all
    max_ref_overlap: int = 0          # max allowed overlap (bp) between adjacent queries on ref
  

This logic require more changes in the previous code:
- pairs of ref mod _contig files need to be transfered as params into NF pipeline. 
- NF pipeline need to run every such pair and evaluate them separately. 


Also, minimap output is saved into <mod_genome_file>.paf output

So far, not tested.