### PR TITLE
EFSA-150: sv_span coverage added

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ For a detailed reference on all hardcoded tool parameters (freebayes, nucmer, cu
 ---
 ## Generation of per structural variation (SV) type CSV tables
 
-These utilities convert SV VCFs into compact TSV summaries, enrich short/long-read SV rows with flank coverage using `mosdepth`, and then merge available summaries into per-SV-type CSV tables.
+These utilities convert SV VCFs into compact TSV summaries, enrich short/long-read SV rows with local coverage using `mosdepth` (100 bp flanks + SV span), and then merge available summaries into per-SV-type CSV tables.
 
 ```mermaid
 flowchart LR
@@ -427,8 +427,9 @@ flowchart LR
 
 - By default a nextflow pipeline is collecting the tables from pipelines and runs restructure_sv_tbl to create all summary tables
 - Variants are extracted into a table format with processes `vcf_to_table` and `vcf_to_table_long`
-- For short-read and long-read SV tables, flank coverage is added by `build_sv_flank_bed` and `mosdepth`:
+- For short-read and long-read SV tables, local coverage is added by `build_sv_flank_bed` and `mosdepth`:
   - `coverage_before_100bp`: mean depth in the 100 bp upstream flank
+  - `coverage_sv_span`: mean depth across the full SV interval (`start..end`)
   - `coverage_after_100bp`: mean depth in the 100 bp downstream flank
 - If one of the pipelines was not running (short/long/assembly) an empty tsv file is generated with a process create_empty_tbl
 - `restructure_sv_tbl` process: the merge step accepts any subset of (assembly, long_ont, long_pacbio, short) and ignores missing files.
@@ -482,8 +483,9 @@ The SV output processing pipeline has been enhanced to handle all structural var
 
 **Coverage handling with mosdepth:**
 - A dedicated step computes short/long-read local depth around each SV event using `mosdepth`
-- Two TSV columns are appended prior to final table merge:
+- Three TSV columns are appended prior to final table merge:
   - `coverage_before_100bp`
+  - `coverage_sv_span`
   - `coverage_after_100bp`
 - Final CSVs expose source-specific coverage columns (`short_*`, `long_ont_*`, `long_pacbio_*`).
 
@@ -555,11 +557,13 @@ The examples below use simplified coordinates for clarity.
 | **long_(ont\|pacbio)_supporting_reads** | Number of Oxford Nanopore or PacBio reads supporting the structural variant (VCF `FORMAT` field `DR`, when present). |
 | **long_(ont\|pacbio)_supporting_methods** | Number or label of long-read variant calling methods supporting the structural variant, derived from the TSV summary when available. |
 | **long_(ont\|pacbio)_coverage_before_100bp** | Mean depth in the 100 bp flank before the long-read SV event, computed by `mosdepth`. |
+| **long_(ont\|pacbio)_coverage_sv_span** | Mean depth across the full long-read SV event span (`start..end`), computed by `mosdepth`. |
 | **long_(ont\|pacbio)_coverage_after_100bp** | Mean depth in the 100 bp flank after the long-read SV event, computed by `mosdepth`. |
 | **short_chr2** | Partner chromosome for short-read translocation/breakend calls (from short-read TSV `chr2`, extracted from VCF `INFO/CHR2`). Empty for non-translocation short-read events or when unavailable. |
 | **short_pos2** | Partner breakpoint position for short-read translocation/breakend calls (from short-read TSV `pos2`, extracted from VCF `INFO/POS2`). Empty for non-translocation short-read events or when unavailable. |
 | **short_reads_copy_number_estimate** | Estimated copy number derived from short-read depth information (VCF `FORMAT` field `RDCN`). |
 | **short_coverage_before_100bp** | Mean depth in the 100 bp flank before the short-read SV event, computed by `mosdepth`. |
+| **short_coverage_sv_span** | Mean depth across the full short-read SV event span (`start..end`), computed by `mosdepth`. |
 | **short_coverage_after_100bp** | Mean depth in the 100 bp flank after the short-read SV event, computed by `mosdepth`. |
 
 ### Source-specific length columns and calculation strategy

--- a/docs/outputs/illumina.md
+++ b/docs/outputs/illumina.md
@@ -2,7 +2,7 @@
 
 ## Pipeline Workflow
 
-The flowchart below summarizes the pipeline for processing short reads. Delly and Freebayes are run exclusively for reference genome mapping; these steps are skipped when reads are mapped to a modified genome or a plasmid. For SV calls, `vcf_to_table_short`, `build_sv_flank_bed`, and `mosdepth` add 100 bp flank coverage metrics to the TSV output.
+The flowchart below summarizes the pipeline for processing short reads. Delly and Freebayes are run exclusively for reference genome mapping; these steps are skipped when reads are mapped to a modified genome or a plasmid. For SV calls, `vcf_to_table_short`, `build_sv_flank_bed`, and `mosdepth` add local coverage metrics (100 bp flanks and SV span) to the TSV output.
 
 ```mermaid
 %%{init: {
@@ -66,7 +66,7 @@ DELLY["Delly (SV calling)"]
 BCF2VCF["Convert BCF to VCF"]
 VCF2TABLE_SHORT["vcf_to_table_short"]
 BUILD_BED_SHORT["build_sv_flank_bed"]
-MOSDEPTH_SHORT["mosdepth (100 bp flanks)"]
+MOSDEPTH_SHORT["mosdepth (100 bp flanks + SV span)"]
 SV_TSV_SHORT["SV TSV + flank coverage"]:::output
 BAM_IDX --> DELLY --> BCF2VCF --> SV_VCF["SV VCF"]:::output
 SV_VCF --> VCF2TABLE_SHORT --> BUILD_BED_SHORT --> MOSDEPTH_SHORT --> SV_TSV_SHORT

--- a/docs/outputs/long-reads.md
+++ b/docs/outputs/long-reads.md
@@ -2,7 +2,7 @@
 
 ## Pipeline Workflow
 
-This workflow shows the processing of raw long-read sequencing data (PacBio or Nanopore) from quality control to mapping. Reads undergo NanoPlot QC, then mapped to the reference or modified genome with minimap2, followed by sorting, indexing, and calculation of unmapped reads. Structural variant calling using cute_sv, debreak, and sniffles is performed only for reads mapped to the reference genome, and results are merged with SURVIVOR and summarized with bcftools stats, producing the final long-read VCF. Reads mapped to modified or plasmid sequences skip structural variant calling. For SV calls, `vcf_to_table_long`, `build_sv_flank_bed`, and `mosdepth` add 100 bp flank coverage metrics to the TSV output.
+This workflow shows the processing of raw long-read sequencing data (PacBio or Nanopore) from quality control to mapping. Reads undergo NanoPlot QC, then mapped to the reference or modified genome with minimap2, followed by sorting, indexing, and calculation of unmapped reads. Structural variant calling using cute_sv, debreak, and sniffles is performed only for reads mapped to the reference genome, and results are merged with SURVIVOR and summarized with bcftools stats, producing the final long-read VCF. Reads mapped to modified or plasmid sequences skip structural variant calling. For SV calls, `vcf_to_table_long`, `build_sv_flank_bed`, and `mosdepth` add local coverage metrics (100 bp flanks and SV span) to the TSV output.
 
 ```mermaid
 %%{init: {
@@ -77,7 +77,7 @@ SURVIVOR["survivor"]
 BCFTOOLS_STATS["bcftools stats"]
 VCF2TABLE_LONG["vcf_to_table_long"]
 BUILD_BED_LONG["build_sv_flank_bed"]
-MOSDEPTH_LONG["mosdepth (100 bp flanks)"]
+MOSDEPTH_LONG["mosdepth (100 bp flanks + SV span)"]
 
 SV_TSV_LONG["SV TSV + flank coverage"]:::output
 LONG_VCF["Long-read VCF"]:::output

--- a/docs/outputs/sv-tables.md
+++ b/docs/outputs/sv-tables.md
@@ -1,6 +1,6 @@
 ## Generation of per structural variation (SV) type CSV tables
 
-These utilities convert SV VCFs into compact TSV summaries, enrich short/long-read SV rows with flank coverage using `mosdepth`, and then merge available summaries into per-SV-type CSV tables.
+These utilities convert SV VCFs into compact TSV summaries, enrich short/long-read SV rows with local coverage using `mosdepth` (100 bp flanks + SV span), and then merge available summaries into per-SV-type CSV tables.
 
 ```mermaid
 flowchart LR
@@ -20,8 +20,9 @@ flowchart LR
 
 - By default a nextflow pipeline is collecting the tables from pipelines and runs restructure_sv_tbl to create all summary tables
 - Variants are extracted into a table format with processes `vcf_to_table` and `vcf_to_table_long`
-- For short-read and long-read SV tables, flank coverage is added by `build_sv_flank_bed` and `mosdepth`:
+- For short-read and long-read SV tables, local coverage is added by `build_sv_flank_bed` and `mosdepth`:
   - `coverage_before_100bp`: mean depth in the 100 bp upstream flank
+  - `coverage_sv_span`: mean depth across the full SV interval (`start..end`)
   - `coverage_after_100bp`: mean depth in the 100 bp downstream flank
 - If one of the pipelines was not running (short/long/assembly) an empty tsv file is generated with a process create_empty_tbl
 - `restructure_sv_tbl` process: the merge step accepts any subset of (assembly, long_ont, long_pacbio, short) and ignores missing files.
@@ -50,14 +51,14 @@ The pipeline extracts variants from VCF files using different fields depending o
 - **Supporting reads:** Extracted from FORMAT/DR (`DR{1}`) for long-read evidence
 - **Supporting methods:** Populated from `INFO/SUPP` and stored in `long_(ont|pacbio)_supporting_methods`
 
-### Flank coverage with mosdepth
+### Local coverage with mosdepth
 
 For short-read and long-read calls, the pipeline adds local depth around each SV event before final table merging:
 
 - **Processes:** `build_sv_flank_bed` (build regions) and `mosdepth` (compute depth)
 - **Input:** indexed BAM + SV TSV (`chrom`, `start`, `end`)
-- **Flanks:** 100 bp upstream and 100 bp downstream of each event
-- **Output columns in TSV:** `coverage_before_100bp`, `coverage_after_100bp`
+- **Regions:** 100 bp upstream flank, full SV span, and 100 bp downstream flank
+- **Output columns in TSV:** `coverage_before_100bp`, `coverage_sv_span`, `coverage_after_100bp`
 - Assembly (`asm`) records are not coverage-enriched because no assembly BAM is used in this step.
 
 ### Variant Type Standardization
@@ -188,11 +189,13 @@ The examples below use simplified coordinates for clarity.
 | **long_(ont\|pacbio)_supporting_reads** | Number of Oxford Nanopore or PacBio reads supporting the structural variant (VCF `FORMAT` field `DR`, when present). |
 | **long_(ont\|pacbio)_supporting_methods** | Number or label of long-read variant calling methods supporting the structural variant, derived from the TSV summary when available. |
 | **long_(ont\|pacbio)_coverage_before_100bp** | Mean depth in the 100 bp flank before the long-read SV event, computed by `mosdepth`. |
+| **long_(ont\|pacbio)_coverage_sv_span** | Mean depth across the full long-read SV event span (`start..end`), computed by `mosdepth`. |
 | **long_(ont\|pacbio)_coverage_after_100bp** | Mean depth in the 100 bp flank after the long-read SV event, computed by `mosdepth`. |
 | **short_chr2** | Partner chromosome for short-read translocation/breakend calls (from short-read TSV `chr2`, extracted from VCF `INFO/CHR2`). Empty for non-translocation short-read events or when unavailable. |
 | **short_pos2** | Partner breakpoint position for short-read translocation/breakend calls (from short-read TSV `pos2`, extracted from VCF `INFO/POS2`). Empty for non-translocation short-read events or when unavailable. |
 | **short_reads_copy_number_estimate** | Estimated copy number derived from short-read depth information (VCF `FORMAT` field `RDCN`). |
 | **short_coverage_before_100bp** | Mean depth in the 100 bp flank before the short-read SV event, computed by `mosdepth`. |
+| **short_coverage_sv_span** | Mean depth across the full short-read SV event span (`start..end`), computed by `mosdepth`. |
 | **short_coverage_after_100bp** | Mean depth in the 100 bp flank after the short-read SV event, computed by `mosdepth`. |
 
 ### Source-specific length columns and calculation strategy

--- a/modules/mapping.nf
+++ b/modules/mapping.nf
@@ -131,6 +131,10 @@ process build_sv_flank_bed {
         b1=start-1
         if (b1 > b0) print chrom, b0, b1, (NR-1)"|before"
 
+        s0=start-1; if (s0 < 0) s0=0
+        s1=end
+        if (s1 > s0) print chrom, s0, s1, (NR-1)"|sv_span"
+
         a0=end; if (a0 < 0) a0=0
         a1=end+100
         if (a1 > a0) print chrom, a0, a1, (NR-1)"|after"
@@ -169,7 +173,7 @@ process mosdepth {
     awk '
       BEGIN{FS=OFS="\\t"}
       NR==FNR { cov[\$1 "|" \$2] = \$3; next }
-      FNR==1 { print \$0, "coverage_before_100bp", "coverage_after_100bp"; next }
+      FNR==1 { print \$0, "coverage_before_100bp", "coverage_sv_span", "coverage_after_100bp"; next }
       function get_cov(id, side, key, value) {
         key = id "|" side
         value = cov[key]
@@ -177,7 +181,7 @@ process mosdepth {
       }
       {
         id = FNR - 1
-        print \$0, get_cov(id, "before"), get_cov(id, "after")
+        print \$0, get_cov(id, "before"), get_cov(id, "sv_span"), get_cov(id, "after")
       }
     ' "\${coverage_tsv}" "${input_sv_tsv}" > "${outfile}"
     """

--- a/modules/utils/create_sv_output.py
+++ b/modules/utils/create_sv_output.py
@@ -118,6 +118,7 @@ ROW_LOG_FIELDS = (
     "start_mod",
     "end_mod",
     "coverage_before_100bp",
+    "coverage_sv_span",
     "coverage_after_100bp",
 )
 
@@ -305,6 +306,7 @@ class Record:
     start_mod: Optional[int] = None
     end_mod: Optional[int] = None
     coverage_before_100bp: Optional[float] = None
+    coverage_sv_span: Optional[float] = None
     coverage_after_100bp: Optional[float] = None
 
 @dataclass
@@ -614,6 +616,7 @@ def load_records(path: Optional[Union[str, Path]], source: str, logger: Any = No
         start_mod = _to_int(row.get("start_mod")) if source == "asm" else None
         end_mod = _to_int(row.get("end_mod")) if source == "asm" else None
         coverage_before_100bp = _to_float(row.get("coverage_before_100bp"))
+        coverage_sv_span = _to_float(row.get("coverage_sv_span"))
         coverage_after_100bp = _to_float(row.get("coverage_after_100bp"))
         svlen_input = _to_int(row.get("svlen"))
         svlen = abs(svlen_input) if svlen_input is not None else None
@@ -722,6 +725,7 @@ def load_records(path: Optional[Union[str, Path]], source: str, logger: Any = No
                 start_mod,
                 end_mod,
                 coverage_before_100bp,
+                coverage_sv_span,
                 coverage_after_100bp,
             )
         )
@@ -864,6 +868,7 @@ def build_output_table(clusters: List[EventCluster]) -> pd.DataFrame:
             "long_ont_supporting_reads": long_ont.supporting_reads if long_ont else np.nan,
             "long_ont_supporting_methods": long_ont.supporting_methods if long_ont else np.nan,
             "long_ont_coverage_before_100bp": long_ont.coverage_before_100bp if long_ont else np.nan,
+            "long_ont_coverage_sv_span": long_ont.coverage_sv_span if long_ont else np.nan,
             "long_ont_coverage_after_100bp": long_ont.coverage_after_100bp if long_ont else np.nan,
 
             "long_pacbio_start": long_pacbio.start if long_pacbio else np.nan,
@@ -874,6 +879,7 @@ def build_output_table(clusters: List[EventCluster]) -> pd.DataFrame:
             "long_pacbio_supporting_reads": long_pacbio.supporting_reads if long_pacbio else np.nan,
             "long_pacbio_supporting_methods": long_pacbio.supporting_methods if long_pacbio else np.nan,
             "long_pacbio_coverage_before_100bp": long_pacbio.coverage_before_100bp if long_pacbio else np.nan,
+            "long_pacbio_coverage_sv_span": long_pacbio.coverage_sv_span if long_pacbio else np.nan,
             "long_pacbio_coverage_after_100bp": long_pacbio.coverage_after_100bp if long_pacbio else np.nan,
 
             "short_start": sht.start if sht else np.nan,
@@ -887,6 +893,7 @@ def build_output_table(clusters: List[EventCluster]) -> pd.DataFrame:
             "short_supporting_reads": sht.supporting_reads if sht else np.nan,
             "short_reads_copy_number_estimate": (sht.copy_number if sht else np.nan),
             "short_coverage_before_100bp": sht.coverage_before_100bp if sht else np.nan,
+            "short_coverage_sv_span": sht.coverage_sv_span if sht else np.nan,
             "short_coverage_after_100bp": sht.coverage_after_100bp if sht else np.nan,
 
             "percentage_overlap": pct_str,


### PR DESCRIPTION
- calculation of coverage within a structural variant
- adding a new column to create_output_table.py for short and long variants
- changing documentation for both long and short pipeline to adjust the change