### PR TITLE
EFSA-287: remove nanoplot qc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,7 +1152,7 @@ The table below summarises all tools used within the pipeline:
 
 ### `pacbio/` and `ont/`
 
-This workflow shows the processing of raw long-read sequencing data (PacBio or Nanopore) from quality control to mapping. Reads undergo NanoPlot QC, then mapped to the reference or modified genome with minimap2, followed by sorting, indexing, and calculation of unmapped reads. Structural variant calling using cute_sv, debreak, and sniffles is performed only for reads mapped to the reference genome, and results are merged with SURVIVOR and summarized with bcftools stats, producing the final long-read VCF. Reads mapped to modified or plasmid sequences skip structural variant calling.
+This workflow shows the processing of raw long-read sequencing data (PacBio or Nanopore) from quality control to mapping. Reads are mapped to the reference or modified genome with minimap2, followed by sorting, indexing, and calculation of unmapped reads. Structural variant calling using cute_sv, debreak, and sniffles is performed only for reads mapped to the reference genome, and results are merged with SURVIVOR and summarized with bcftools stats, producing the final long-read VCF. Reads mapped to modified or plasmid sequences skip structural variant calling.
 
 ```mermaid
 %%{init: {
@@ -1179,13 +1179,10 @@ style REF fill:#E3F2FD,stroke:#1565C0,stroke-width:2px
 style PLASMID_REF fill:#E3F2FD,stroke:#1565C0,stroke-width:2px
 
 %% ===== QC =====
-NANO_PLOT["NanoPlot QC"]
 MULTIQC_QC["MultiQC (QC)"]
-NANO_PLOT_OUT["NanoPlot QC report"]:::output
 MULTIQC_QC_OUT["MultiQC QC report"]:::output
 
-LONG_READS --> NANO_PLOT --> MULTIQC_QC
-NANO_PLOT --> NANO_PLOT_OUT
+LONG_READS --> MULTIQC_QC
 MULTIQC_QC --> MULTIQC_QC_OUT
 
 %% ===== LONG REF MAPPING PIPELINE =====
@@ -1269,8 +1266,6 @@ data/outputs/pacbio/
 ├── long-ref-plasmid
 │   ├── bam
 │   └── unmapped_fastq
-└── nanoplot
-    └── SampleName_report
 ```
 
 #### `long-ref/`
@@ -1323,22 +1318,6 @@ Includes:
 
 This enables comparison between mapping reads on reference vs modified assemblies.
 
-#### `nanoplot/`
-
-Contains long-read quality control and summary statistics generated using **NanoPlot**.
-
-Example content:
-
-* `SampleName_report/`
-
-Inside this folder you typically find:
-
-* Read length distributions
-* N50 / N90 statistics
-* Quality score profiles
-* Read length vs quality plots
-* Summary statistics of long-read sequencing quality
-
 The table below summarises all tools used within the pipeline:
 
 | **Tool**     | **Link for Further Information**                       |
@@ -1349,7 +1328,6 @@ The table below summarises all tools used within the pipeline:
 | **DeBreak**  | [DeBreak](https://github.com/Maggi-Chen/DeBreak)       |
 | **Sniffles** | [Sniffles](https://github.com/fritzsedlazeck/Sniffles) |
 | **SURVIVOR** | [SURVIVOR](https://github.com/fritzsedlazeck/SURVIVOR) |
-| **NanoPlot** | [NanoPlot](https://github.com/wdecoster/NanoPlot)      |
 
 
 ### `unmapped_stats/`
@@ -1429,13 +1407,10 @@ style MOD_REF fill:#E3F2FD,stroke:#1565C0,stroke-width:2px
 style PLASMID_REF fill:#E3F2FD,stroke:#1565C0,stroke-width:2px
 
 %% ===== QC =====
-NANO_PLOT["NanoPlot QC"]
 MULTIQC_QC["MultiQC (QC)"]
-NANO_PLOT_OUT["NanoPlot QC report"]:::output
 MULTIQC_QC_OUT["MultiQC QC report"]:::output
 
-LONG_READS --> NANO_PLOT --> MULTIQC_QC
-NANO_PLOT --> NANO_PLOT_OUT
+LONG_READS --> MULTIQC_QC
 MULTIQC_QC --> MULTIQC_QC_OUT
 
 %% ===============================

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -64,7 +64,6 @@ EUPL-1.2 is a copyleft license. Its Appendix explicitly lists compatible license
 |---|---|---|---|
 | FastQC | 0.11.9 | GPL-3.0-or-later | https://github.com/s-andrews/FastQC |
 | MultiQC | 1.33 | GPL-3.0-or-later | https://github.com/MultiQC/MultiQC |
-| NanoPlot | 1.46.2 | MIT | https://github.com/wdecoster/NanoPlot |
 | mosdepth | 0.3.12 | MIT | https://github.com/brentp/mosdepth |
 
 ### Read Processing
@@ -134,7 +133,6 @@ EUPL-1.2 is a copyleft license. Its Appendix explicitly lists compatible license
 | staphb/samtools | 1.23@sha256:ed378537... | https://github.com/StaPH-B/docker-builds |
 | staphb/htslib | 1.23@sha256:400e7c4e... | https://github.com/StaPH-B/docker-builds |
 | staphb/mummer | 4.0.1@sha256:f4106644... | https://github.com/StaPH-B/docker-builds |
-| staphb/nanoplot | 1.46.2@sha256:824dbbe1... | https://github.com/StaPH-B/docker-builds |
 | staphb/multiqc | 1.33@sha256:4dbb26ba... | https://github.com/StaPH-B/docker-builds |
 | biocontainers/bwa | v0.7.17_cv1@sha256:9479b73e... | https://biocontainers.pro |
 | biocontainers/fastqc | v0.11.9_cv8@sha256:82e5fa41... | https://biocontainers.pro |

--- a/docs/outputs/long-reads.md
+++ b/docs/outputs/long-reads.md
@@ -2,7 +2,7 @@
 
 ## Pipeline Workflow
 
-This workflow shows the processing of raw long-read sequencing data (PacBio or Nanopore) from quality control to mapping. Reads undergo NanoPlot QC, then mapped to the reference or modified genome with minimap2, followed by sorting, indexing, and calculation of unmapped reads. Structural variant calling using cute_sv, debreak, and sniffles is performed only for reads mapped to the reference genome, and results are merged with SURVIVOR and summarized with bcftools stats, producing the final long-read VCF. Reads mapped to modified or plasmid sequences skip structural variant calling. For SV calls, `vcf_to_table_long`, `build_sv_flank_bed`, and `mosdepth` add local coverage metrics (100 bp flanks and SV span) to the TSV output.
+This workflow shows the processing of raw long-read sequencing data (PacBio or Nanopore) from quality control to mapping. Reads are mapped to the reference or modified genome with minimap2, followed by sorting, indexing, and calculation of unmapped reads. Structural variant calling using cute_sv, debreak, and sniffles is performed only for reads mapped to the reference genome, and results are merged with SURVIVOR and summarized with bcftools stats, producing the final long-read VCF. Reads mapped to modified or plasmid sequences skip structural variant calling. For SV calls, `vcf_to_table_long`, `build_sv_flank_bed`, and `mosdepth` add local coverage metrics (100 bp flanks and SV span) to the TSV output.
 
 ```mermaid
 %%{init: {
@@ -29,13 +29,10 @@ style REF fill:#E3F2FD,stroke:#1565C0,stroke-width:2px
 style PLASMID_REF fill:#E3F2FD,stroke:#1565C0,stroke-width:2px
 
 %% ===== QC =====
-NANO_PLOT["NanoPlot QC"]
 MULTIQC_QC["MultiQC (QC)"]
-NANO_PLOT_OUT["NanoPlot QC report"]:::output
 MULTIQC_QC_OUT["MultiQC QC report"]:::output
 
-LONG_READS --> NANO_PLOT --> MULTIQC_QC
-NANO_PLOT --> NANO_PLOT_OUT
+LONG_READS --> MULTIQC_QC
 MULTIQC_QC --> MULTIQC_QC_OUT
 
 %% ===== LONG REF MAPPING PIPELINE =====
@@ -113,7 +110,7 @@ Both follow the **same folder structure** and processing logic.
 ## Directory Structure
 
 ```
-data/outputs/ont/
+data/outputs/ont/ (if files present, otherwise only samtools_index_dict)
 data/outputs/pacbio/
 ├── long-mod
 │   ├── bam
@@ -129,8 +126,6 @@ data/outputs/pacbio/
 ├── long-ref-plasmid
 │   ├── bam
 │   └── unmapped_fastq
-└── nanoplot
-    └── SampleName_report
 ```
 
 ## Output Subdirectories
@@ -169,22 +164,6 @@ Includes:
 
 This enables comparison between mapping reads on reference vs modified assemblies.
 
-### `nanoplot/`
-
-Contains long-read quality control and summary statistics generated using **NanoPlot**.
-
-Example content:
-
-- `SampleName_report/`
-
-Inside this folder you typically find:
-
-- Read length distributions
-- N50 / N90 statistics
-- Quality score profiles
-- Read length vs quality plots
-- Summary statistics of long-read sequencing quality
-
 ## Tools Used
 
 The table below summarises all tools used within the pipeline:
@@ -197,7 +176,6 @@ The table below summarises all tools used within the pipeline:
 | **DeBreak**  | [DeBreak](https://github.com/Maggi-Chen/DeBreak)       |
 | **Sniffles** | [Sniffles](https://github.com/fritzsedlazeck/Sniffles) |
 | **SURVIVOR** | [SURVIVOR](https://github.com/fritzsedlazeck/SURVIVOR) |
-| **NanoPlot** | [NanoPlot](https://github.com/wdecoster/NanoPlot)      |
 
 ## Citation
 

--- a/docs/outputs/unmapped-stats.md
+++ b/docs/outputs/unmapped-stats.md
@@ -77,13 +77,10 @@ style MOD_REF fill:#E3F2FD,stroke:#1565C0,stroke-width:2px
 style PLASMID_REF fill:#E3F2FD,stroke:#1565C0,stroke-width:2px
 
 %% ===== QC =====
-NANO_PLOT["NanoPlot QC"]
 MULTIQC_QC["MultiQC (QC)"]
-NANO_PLOT_OUT["NanoPlot QC report"]:::output
 MULTIQC_QC_OUT["MultiQC QC report"]:::output
 
-LONG_READS --> NANO_PLOT --> MULTIQC_QC
-NANO_PLOT --> NANO_PLOT_OUT
+LONG_READS --> MULTIQC_QC
 MULTIQC_QC --> MULTIQC_QC_OUT
 
 %% ===============================

--- a/docs/project/third-party-licenses.md
+++ b/docs/project/third-party-licenses.md
@@ -65,7 +65,6 @@ EUPL-1.2 is a copyleft license. Its Appendix explicitly lists compatible license
 |---|---|---|---|
 | FastQC | 0.11.9 | GPL-3.0-or-later | https://github.com/s-andrews/FastQC |
 | MultiQC | 1.33 | GPL-3.0-or-later | https://github.com/MultiQC/MultiQC |
-| NanoPlot | 1.46.2 | MIT | https://github.com/wdecoster/NanoPlot |
 | mosdepth | 0.3.12 | MIT | https://github.com/brentp/mosdepth |
 
 ### Read Processing
@@ -135,7 +134,6 @@ EUPL-1.2 is a copyleft license. Its Appendix explicitly lists compatible license
 | staphb/samtools | 1.23@sha256:ed378537... | https://github.com/StaPH-B/docker-builds |
 | staphb/htslib | 1.23@sha256:400e7c4e... | https://github.com/StaPH-B/docker-builds |
 | staphb/mummer | 4.0.1@sha256:f4106644... | https://github.com/StaPH-B/docker-builds |
-| staphb/nanoplot | 1.46.2@sha256:824dbbe1... | https://github.com/StaPH-B/docker-builds |
 | staphb/multiqc | 1.33@sha256:4dbb26ba... | https://github.com/StaPH-B/docker-builds |
 | biocontainers/bwa | v0.7.17_cv1@sha256:9479b73e... | https://biocontainers.pro |
 | biocontainers/fastqc | v0.11.9_cv8@sha256:82e5fa41... | https://biocontainers.pro |

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -61,23 +61,3 @@ process multiqc {
     multiqc --filename ${filename} .
     """
 }
-
-
-// Processes for long-read pipeline
-
-process nanoplot {
-
-    publishDir "${params.out_dir}/${out_folder_name}/nanoplot", mode: "copy"
-
-    input:
-    tuple val(pair_id), path(reads)
-    val out_folder_name
-    
-    output:
-    path("${pair_id}_report")
-    
-    script:
-    """
-    NanoPlot --huge --fastq $reads --outdir ${pair_id}_report --threads ${task.cpus}
-    """
-}

--- a/nextflow.config
+++ b/nextflow.config
@@ -84,13 +84,6 @@ process {
     container = 'staphb/samtools:1.23@sha256:ed3785374d84fff0fe41243984d163d67feba3785ef573bdbaab54aae3d9acf8'
   }
 
-  withName: nanoplot {
-    container = 'staphb/nanoplot:1.46.2@sha256:824dbbe135ff5aa66b62c58864df2334adbbdfe2718a967569df4626ceb603e1'
-    cpus = Math.min(params.max_cpu as int, 8)
-    memory = '32 GB'
-    time = '8h'
-  }
-
   withName: fastqc {
     container = 'biocontainers/fastqc:v0.11.9_cv8@sha256:82e5fa413d275a72c3de76e400a3d12a93ebdb4e1ef5391d7f7e9ce686671d8d'
   }

--- a/sbom.spdx.json
+++ b/sbom.spdx.json
@@ -328,24 +328,7 @@
         }
       ]
     },
-    {
-      "SPDXID": "SPDXRef-nanoplot",
-      "name": "NanoPlot",
-      "versionInfo": "1.46.2",
-      "downloadLocation": "https://github.com/wdecoster/NanoPlot/releases/tag/v1.46.2",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "supplier": "Person: Wouter De Coster",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/NanoPlot@1.46.2"
-        }
-      ]
-    },
+
     {
       "SPDXID": "SPDXRef-trimgalore",
       "name": "TrimGalore",
@@ -557,7 +540,6 @@
     {"spdxElementId": "SPDXRef-efsa-pipeline", "relationshipType": "RUNTIME_DEPENDENCY_OF", "relatedSpdxElement": "SPDXRef-gffread"},
     {"spdxElementId": "SPDXRef-efsa-pipeline", "relationshipType": "RUNTIME_DEPENDENCY_OF", "relatedSpdxElement": "SPDXRef-fastqc"},
     {"spdxElementId": "SPDXRef-efsa-pipeline", "relationshipType": "RUNTIME_DEPENDENCY_OF", "relatedSpdxElement": "SPDXRef-multiqc"},
-    {"spdxElementId": "SPDXRef-efsa-pipeline", "relationshipType": "RUNTIME_DEPENDENCY_OF", "relatedSpdxElement": "SPDXRef-nanoplot"},
     {"spdxElementId": "SPDXRef-efsa-pipeline", "relationshipType": "RUNTIME_DEPENDENCY_OF", "relatedSpdxElement": "SPDXRef-trimgalore"},
     {"spdxElementId": "SPDXRef-efsa-pipeline", "relationshipType": "RUNTIME_DEPENDENCY_OF", "relatedSpdxElement": "SPDXRef-cutadapt"},
     {"spdxElementId": "SPDXRef-efsa-pipeline", "relationshipType": "RUNTIME_DEPENDENCY_OF", "relatedSpdxElement": "SPDXRef-pbzip2"},

--- a/workflows/analysis.nf
+++ b/workflows/analysis.nf
@@ -7,7 +7,6 @@ include { short_read as short_ref; short_read as short_mod } from "./short_read.
 include { qc } from "./subworkflows.nf"
 
 include { compare_unmapped; compare_unmapped as compare_unmapped_ont; compare_unmapped as compare_unmapped_pacbio } from "../modules/mapping.nf"
-include { nanoplot as nanoplot_pacbio; nanoplot as nanoplot_ont } from "../modules/qc.nf"
 include { restructure_sv_tbl; create_empty_tbl as create_ont_tbl; create_empty_tbl as create_asm_tbl; create_empty_tbl as create_pacbio_tbl; create_empty_tbl as create_short_tbl } from "../modules/sv_calling.nf"
 
 
@@ -52,8 +51,6 @@ workflow analysis {
             .flatMap { it.pacbio_fastqs }
             .map(toNamedFastq)
 
-        nanoplot_pacbio(pacbio_fastqs, "pacbio")
-
         long_ref_pacbio(pacbio_fastqs, ref_fasta, "map-pb", ref_plasmid, "pacbio/long-ref")
         long_mod_pacbio(pacbio_fastqs, mod_fasta, "map-pb", mod_plasmid, "pacbio/long-mod")
         compare_unmapped_pacbio(long_ref_pacbio.out.unmapped_fastq, long_mod_pacbio.out.unmapped_fastq, "pacbio")
@@ -66,8 +63,6 @@ workflow analysis {
             .filter { it.run_nanopore }
             .flatMap { it.ont_fastqs }
             .map(toNamedFastq)
-
-        nanoplot_ont(ont_fastqs, "ont")
 
         long_ref_ont(ont_fastqs, ref_fasta, "map-ont", ref_plasmid, "ont/long-ref")
         long_mod_ont(ont_fastqs, mod_fasta, "map-ont", mod_plasmid, "ont/long-mod")


### PR DESCRIPTION
Related issue #287 

When dev is updated with lint the error with [CI: Nextflow Integration Test / integration-test (pull_request)](https://github.com/denisHanch/efsa_pipeline/actions/runs/25598767651/job/75149119755?pr=290) will not fail.

It should be merged when dev is updated with https://github.com/denisHanch/efsa_pipeline/pull/277