### PR TITLE
EFSA-286: delete params

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,8 @@ By default, runtime logs are written to `data/outputs/logs/nextflow.log` and con
 | `-with-timeline` | Generate a timeline visualization showing when each pipeline process started and finished. The timeline is saved by default to `data/outputs/logs/timeline.html`.                   |
 | `-with-dag`      | Generate a directed acyclic graph (DAG) illustrating task dependencies in the workflow.                                                                                             |
 
+> **Note:** `-resume` is not supported in this pipeline. The `work/` directory is automatically deleted at the end of every run — including failed runs — so Nextflow has no cached task outputs to resume from.
+
 
 ### Available Options
 
@@ -755,6 +757,7 @@ At pipeline completion, the workflow attempts to remove the temporary `work/` di
 
 * The `work/` directory contains intermediate files and temporary outputs generated during pipeline execution.
 * Removing it saves disk space while retaining all final results in the `out_dir`.
+* Because the `work/` directory is removed even on failure, `-resume` is not supported — every run starts fresh.
 
 
 ## 📁 `data/valid` Directory Structure

--- a/docs/nextflow/running-pipeline.md
+++ b/docs/nextflow/running-pipeline.md
@@ -44,6 +44,8 @@ NXF_QUIET=false nextflow run main.nf --max_cpu $(nproc)
 | `-with-timeline` | Generate a timeline visualization showing when each pipeline process started and finished. The timeline is saved by default to `data/outputs/logs/timeline.html`.                   |
 | `-with-dag`      | Generate a directed acyclic graph (DAG) illustrating task dependencies in the workflow.                                                                                             |
 
+> **Note:** `-resume` is not supported in this pipeline. The `work/` directory is automatically deleted at the end of every run — including failed runs — so Nextflow has no cached task outputs to resume from.
+
 
 ## Pipeline Options
 

--- a/docs/validation/FILE_FORMATS.md
+++ b/docs/validation/FILE_FORMATS.md
@@ -41,7 +41,7 @@ The EFSA Pipeline validation module supports various file formats for genomic da
 - BED files are automatically converted to GFF3 format
 - Output is always uncompressed
 - If `gffread` fails or returns 0 features, the validator falls back to direct GFF3 parsing
-- If both `gffread` and the fallback parser return 0 features, validation fails: no output file is created and `run_vcf_annotation` is set to `false` in `validated_params.json`
+- If both `gffread` and the fallback parser return 0 features, validation fails: no output file is created
 - Coordinate validation (`start >= 1`, `start <= end`) runs in strict mode; issues are reported as warnings
 
 ## File Organization

--- a/docs/validation/OVERVIEW.md
+++ b/docs/validation/OVERVIEW.md
@@ -88,7 +88,6 @@ This file is produced by the validation step and consumed by the pipeline workfl
 | `run_nanopore`          | boolean | `true` when validated Nanopore (ONT) reads are present (FASTQ or BAM).                               |
 | `run_pacbio`            | boolean | `true` when validated PacBio reads are present (FASTQ or BAM).                                       |
 | `contig_file_size`      | integer | Number of contig files produced by inter-genome characterisation.                                     |
-| `run_vcf_annotation`    | boolean | `true` when a validated GFF feature file is available.                                                |
 | `validation_timestamp`  | string  | Timestamp of the validation run (`YYYYMMDD_HHMMSS`).                                                  |
 
 #### File paths (null or empty list when absent)

--- a/modules/validate.nf
+++ b/modules/validate.nf
@@ -10,7 +10,7 @@ process validate {
 
     output:
     path 'validated_params.json', emit: params_json
-    path 'run_*/**', emit: run_dir
+    path '{*.fasta,*.fasta.gz,*.gff,*.gff3,*.tsv,*/*.fastq.gz,*/*.bam}', optional: true, emit: validated_files
 
     script:
     def val_level_arg  = params.validation_level     ? "--validation-level ${params.validation_level}"  : ""

--- a/modules/validation/main.py
+++ b/modules/validation/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import os
 import sys
 import traceback
 from pathlib import Path
@@ -51,19 +50,15 @@ def main():
     if parsed.organism_type      is not None: cli_options["type"]                = parsed.organism_type
     if parsed.force_defragment_ref:           cli_options["force_defragment_ref"] = True
 
-    base_valid_dir = Path.cwd()
-    # Use the run-specific dir exported by validation.sh; fall back to CWD.
-    run_dir = os.environ.get("VALIDATION_RUN_DIR")
-    output_dir = Path(run_dir).resolve() if run_dir else base_valid_dir
+    output_dir = Path.cwd()
     output_dir.mkdir(parents=True, exist_ok=True)
-    run_id = output_dir.name.removeprefix("run_") if output_dir.name.startswith("run_") else None
     logs_dir = config_path.parent.parent / "outputs" / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
     logger = None
     log_file = None
 
     # Setup logging
-    log_filename = f"validation_{run_id}.log" if run_id else "validation.log"
+    log_filename = "validation.log"
     try:
         logger = setup_logging(console_level='DEBUG', log_file=logs_dir / log_filename)
     except (PermissionError, OSError) as e:
@@ -81,11 +76,8 @@ def main():
         logger.error(f"Loading a config file failed: {e}")
         return 1
 
-    # Redirect all validator configs to write into the run-specific output_dir.
-    # ConfigManager sets config.output_dir from the config file's location on
-    # disk (e.g. the real data/valid/ in the project root), which is wrong when
-    # running inside a Nextflow work directory.  Override every sub-config here
-    # so genome, read, and feature outputs all land in the same run_* folder.
+    # Override sub-config output dirs to CWD. ConfigManager sets output_dir from
+    # the config file location, which is wrong inside a Nextflow work directory.
     _all_sub_configs = [
         config.ref_genome, config.mod_genome,
         config.ref_plasmid, config.mod_plasmid,
@@ -215,7 +207,7 @@ def main():
     # ========================================================================
     # Step 3: Run validation using functional API
     # ========================================================================
-    report_filename = f"report_{run_id}.txt" if run_id else "report.txt"
+    report_filename = "report.txt"
     report = ValidationReport(logs_dir / report_filename)
     fatal_errors: list[str] = []
 
@@ -334,8 +326,8 @@ def main():
             "skipped. Feature coordinates are not meaningful on a defragmented reference."
         )
     repo_root = config_path.parent.parent.parent
-    params = nf_params.build_params(validation_results, run_timestamp=run_id, base_dir=repo_root)
-    nf_params.write_params(params, base_valid_dir / "validated_params.json")
+    params = nf_params.build_params(validation_results, base_dir=repo_root)
+    nf_params.write_params(params, output_dir / "validated_params.json")
 
     return 0
 

--- a/modules/validation/main.py
+++ b/modules/validation/main.py
@@ -331,8 +331,7 @@ def main():
     if force_defragment:
         logger.warning(
             "force_defragment_ref is active: GFF validation for the reference is "
-            "skipped. Feature coordinates are not meaningful on a defragmented "
-            "reference — run_vcf_annotation will be disabled."
+            "skipped. Feature coordinates are not meaningful on a defragmented reference."
         )
     repo_root = config_path.parent.parent.parent
     params = nf_params.build_params(validation_results, run_timestamp=run_id, base_dir=repo_root)

--- a/modules/validation/utils/tests/test_nextflow_params.py
+++ b/modules/validation/utils/tests/test_nextflow_params.py
@@ -4,8 +4,7 @@ Tests for nextflow_params.py
 Tests cover:
 - run_ref_x_mod conditions
 - Read type detection (illumina, ont, pacbio)
-- GFF / run_vcf_annotation
-- Conditional keys (ref_fasta_validated, mod_fasta_validated, pacbio_fastq, gff)
+- Conditional keys (ref_fasta_validated, mod_fasta_validated, pacbio_fastq)
 - write_params serialises valid JSON
 """
 

--- a/modules/validation/validation-pkg/validation_pkg/config_manager.py
+++ b/modules/validation/validation-pkg/validation_pkg/config_manager.py
@@ -685,9 +685,7 @@ class ConfigManager:
         """Set up output directory for validation results."""
         logger = get_logger()
 
-        # Create output directory path — prefer the run-specific dir set by validation.sh
-        run_dir = os.environ.get("VALIDATION_RUN_DIR")
-        output_dir = Path(run_dir) if run_dir else config.config_dir.parent / "valid"
+        output_dir = config.config_dir.parent / "outputs" / "valid"
 
         # Create directory if it doesn't exist
         try:

--- a/modules/validation/validation.sh
+++ b/modules/validation/validation.sh
@@ -74,13 +74,6 @@ if [ ! -x "$VENV_PYTHON" ]; then
     exit 1
 fi
 
-# Create run-stamped staging directory instead of destructively clearing the output dir
-RUN_ID="$(date +%Y%m%d_%H%M%S)"
-STAGING_DIR="./run_${RUN_ID}"
-mkdir -p "$STAGING_DIR"
-echo "Validation outputs will be written under: $STAGING_DIR"
-export VALIDATION_RUN_DIR="$STAGING_DIR"
-
 # Build extra args array (only include options that were explicitly set)
 EXTRA_ARGS=()
 [[ -n "$THREADS"           ]] && EXTRA_ARGS+=(--threads "$THREADS")

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,7 +3,7 @@ params {
   config_json = "${projectDir}/data/inputs/config.json"
   out_dir = 'data/outputs'
   log_dir = 'data/outputs/logs'
-  valid_dir = 'data/valid'
+  valid_dir = 'data/outputs/valid'
 
   help = false
   max_cpu = 1
@@ -209,11 +209,11 @@ process {
   }
 
   withName: restructure_sv_tbl {
-    container = 'ecomolegmo/validation:v1.0.6@sha256:d70845a291ec1d055cdfe710467f553479df4fe0870fbaaceb6fb4b35a88301d'
+    container = 'ecomolegmo/validation:v1.0.7@sha256:e6d49cc5f6223425d718fc85ff035e06c4e52d59bf2ba0faf830ae2f4420b53a'
   }
 
   withName: validate {
-    container = 'ecomolegmo/validation:v1.0.6@sha256:d70845a291ec1d055cdfe710467f553479df4fe0870fbaaceb6fb4b35a88301d'
+    container = 'ecomolegmo/validation:v1.0.7@sha256:e6d49cc5f6223425d718fc85ff035e06c4e52d59bf2ba0faf830ae2f4420b53a'
     memory = '8 GB'
     time = '1h'
   }


### PR DESCRIPTION
In this PR:

    run_vcf_annotation parameter was deleted
    timestamp removed for validation outputs
    validation outputs moved from data/valid/ into data/outputs/valid/