### PR TITLE
EFSA-282: report % of event length

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,9 @@ python3 modules/utils/create_sv_output.py --asm assembly_sv_summary.tsv \
   --long_ont sample1_ont_sv_summary.tsv \
   --long_pacbio sample1_pacbio_sv_summary.tsv \
   --short sample1_short_sv_summary.tsv \
-  --out csv_per_sv_sumary
+  --out csv_per_sv_sumary \
+  --ref_size 4.8Mbp \
+  --mod_size 4.9Mbp
 ```
 
 ### All supported processing script options
@@ -526,6 +528,8 @@ python3 modules/utils/create_sv_output.py --asm assembly_sv_summary.tsv \
 | `--out` | Output directory for the per-SV CSV files. Required. |
 | `--tol` | Within-type clustering tolerance in base pairs. Determines whether raw SV calls get merged into the same event. Default: `10`. |
 | `--cross_type_tol` | Tolerance in base pairs for linking final events with near-identical coordinates in `linked_event`. Default: `0`, which keeps overlap-only linking. |
+| `--ref_size` | Reference genome size used to calculate `pct_of_ref_genome` as `event_length_bp / ref_size * 100`. Optional. Accepts plain bp values or suffixes such as `kb`, `kbp`, `Mb`, `Mbp`, `Gb`, or `Gbp`. |
+| `--mod_size` | Modified genome or assembly size used to calculate `pct_of_mod_genome` as `event_length_bp / mod_size * 100`. Optional. Accepts plain bp values or suffixes such as `kb`, `kbp`, `Mb`, `Mbp`, `Gb`, or `Gbp`. |
 
 ### Explanation of `csv_per_sv_summary` CSV columns
 
@@ -548,6 +552,8 @@ The final table in each CSV file contains one row per final structural variant (
 | **event_start** | Start coordinate of the selected representative call used to anchor the final event. By design, this is taken from the same source call that determines `event_length_bp` (minimum absolute `svlen`). |
 | **event_end** | End coordinate of the selected representative call used to anchor the final event. By design, this is taken from the same source call that determines `event_length_bp` (minimum absolute `svlen`). |
 | **event_length_bp** | Representative event size in base pairs, computed as the minimum available **absolute** `svlen` (`min(abs(svlen))`) across assembly, long ONT, long PacBio, and short source representatives. If no source provides `svlen`, this field is `NaN` and coordinates fall back to type-aware cluster coordinate logic. |
+| **pct_of_ref_genome** | Percentage of the reference genome covered by the representative event length, calculated as `event_length_bp / --ref_size * 100`. Empty/`NaN` unless `--ref_size` is provided and `event_length_bp` is available. |
+| **pct_of_mod_genome** | Percentage of the modified genome or assembly covered by the representative event length, calculated as `event_length_bp / --mod_size * 100`. Empty/`NaN` unless `--mod_size` is provided and `event_length_bp` is available. |
 | **support_score** | Number of input sources contributing to the final event row. In the current implementation this is the count of non-empty calls among `asm`, `long_ont`, `long_pacbio`, and `short`. |
 | **percentage_overlap** | Comma-separated overlap percentages collected during same-type event clustering. Each value is calculated during one clustering merge step as `(intersection length / longer interval length) × 100`. This field is empty when the final event was built from a single record only. |
 | **linked_event** | Semicolon-separated list of overlapping final SV events on the same chromosome. This single column includes both same-type and cross-type links. Each linked entry has the format `<event_id> (<std_svtype>, <chrom>:<start>-<end>, <relation>)`. Standard relation values are `exact_coordinates`, `overlap`, `nested_in`, and `contains`, always from the point of view of the current row. If `--cross_type_tol` is set above `0`, near-identical boundaries may also be reported as `same_coordinates_within_<N>bp`. Leave empty when no linked events are found. |

--- a/docs/outputs/sv-tables.md
+++ b/docs/outputs/sv-tables.md
@@ -130,8 +130,12 @@ python3 modules/utils/create_sv_output.py --asm assembly_sv_summary.tsv \
   --long_ont sample1_ont_sv_summary.tsv \
   --long_pacbio sample1_pacbio_sv_summary.tsv \
   --short sample1_short_sv_summary.tsv \
-  --out csv_per_sv_sumary
+  --out csv_per_sv_sumary \
+  --ref_size 4.8Mbp \
+  --mod_size 4.9Mbp
 ```
+
+`--ref_size` and `--mod_size` are optional. Provide them when you want `pct_of_ref_genome` and `pct_of_mod_genome` to be populated; otherwise those percentage columns are written but left empty/`NaN`.
 
 ### All supported processing script options
 
@@ -144,6 +148,8 @@ python3 modules/utils/create_sv_output.py --asm assembly_sv_summary.tsv \
 | `--out` | Output directory for the per-SV CSV files. Required. |
 | `--tol` | Within-type clustering tolerance in base pairs. Determines whether raw SV calls get merged into the same event. Default: `10`. |
 | `--cross_type_tol` | Tolerance in base pairs for linking final events with near-identical coordinates in `linked_event`. Default: `0`, which keeps overlap-only linking. |
+| `--ref_size` | Reference genome size used to calculate `pct_of_ref_genome` as `event_length_bp / ref_size * 100`. Optional. Accepts plain bp values or suffixes such as `kb`, `kbp`, `Mb`, `Mbp`, `Gb`, or `Gbp`. |
+| `--mod_size` | Modified genome or assembly size used to calculate `pct_of_mod_genome` as `event_length_bp / mod_size * 100`. Optional. Accepts plain bp values or suffixes such as `kb`, `kbp`, `Mb`, `Mbp`, `Gb`, or `Gbp`. |
 
 ### Explanation of `csv_per_sv_summary` CSV columns
 
@@ -166,6 +172,8 @@ The final table in each CSV file contains one row per final structural variant (
 | **event_start** | Start coordinate of the selected representative call used to anchor the final event. This is taken from the same source call that determines `event_length_bp` (minimum absolute `svlen`). |
 | **event_end** | End coordinate of the selected representative call used to anchor the final event. This is taken from the same source call that determines `event_length_bp` (minimum absolute `svlen`). |
 | **event_length_bp** | Representative event size in base pairs, computed as the minimum available **absolute** source length (`min(abs(svlen))`) across assembly, long ONT, long PacBio, and short source representatives. If no source provides `svlen`, this field is `NaN` and coordinates use fallback cluster logic. |
+| **pct_of_ref_genome** | Percentage of the reference genome covered by the representative event length, calculated as `event_length_bp / --ref_size * 100`. Empty/`NaN` unless `--ref_size` is provided and `event_length_bp` is available. |
+| **pct_of_mod_genome** | Percentage of the modified genome or assembly covered by the representative event length, calculated as `event_length_bp / --mod_size * 100`. Empty/`NaN` unless `--mod_size` is provided and `event_length_bp` is available. |
 | **support_score** | Number of input sources contributing to the final event row. In the current implementation this is the count of non-empty calls among `asm`, `long_ont`, `long_pacbio`, and `short`. |
 | **percentage_overlap** | Comma-separated overlap percentages collected during same-type event clustering. Each value is calculated during one clustering merge step as `(intersection length / longer interval length) × 100`. This field is empty when the final event was built from a single record only. |
 | **linked_event** | Semicolon-separated list of overlapping final SV events on the same chromosome. This single column includes both same-type and cross-type links. Each linked entry has the format `<event_id> (<std_svtype>, <chrom>:<start>-<end>, <relation>)`. Standard relation values are `exact_coordinates`, `overlap`, `nested_in`, and `contains`, always from the point of view of the current row. If `--cross_type_tol` is set above `0`, near-identical boundaries may also be reported as `same_coordinates_within_<N>bp`. Leave empty when no linked events are found. |

--- a/modules/utils/create_sv_output.py
+++ b/modules/utils/create_sv_output.py
@@ -33,7 +33,14 @@ events for both same-type and cross-type SV rows. Set --cross_type_tol to a smal
 integer to also link near-identical final coordinates.
 
 Usage:
-    python create_sv_output.py --asm assembly.tsv --long_ont long_ont.tsv --long_pacbio long_pb.tsv --short short.tsv --out outdir --tol 10 --cross_type_tol 0
+    python create_sv_output.py --asm assembly.tsv --long_ont long_ont.tsv --long_pacbio long_pb.tsv --short short.tsv --out outdir --tol 10 --cross_type_tol 0 [--ref_size 4Gbp] [--mod_size 4.5Gbp]
+
+Optional genome-size arguments:
+    --ref_size SIZE   Size of the reference genome (e.g. 4Gbp, 2.7G, 500Mb, 3000000000).
+                      Adds a pct_of_ref_genome column: event_length_bp / ref_size * 100.
+    --mod_size SIZE   Size of the modified genome or assembly (e.g. 4.5Gbp).
+                      Adds a pct_of_mod_genome column: event_length_bp / mod_size * 100.
+                      Both columns are NaN when the genome size or event length is unavailable.
 
 Any of the inputs may be omitted; the script will process whichever of the assembly, long_ont,
 long_pacbio or short tables are provided. Long-read inputs (ONT and PacBio) are treated
@@ -249,6 +256,48 @@ def _is_missing(value: Any) -> bool:
         return bool(pd.isna(value))
     except Exception:
         return False
+
+def _parse_genome_size(value: Optional[str]) -> Optional[int]:
+    """Parse a genome size string into an integer number of base pairs.
+
+    Accepts plain integers or values with SI/genomics suffixes (case-insensitive):
+      k / kb / kbp  → × 1 000
+      m / mb / mbp  → × 1 000 000
+      g / gb / gbp  → × 1 000 000 000
+
+    Examples:
+      "4Gbp"  → 4_000_000_000
+      "4.5G"  → 4_500_000_000
+      "500Mb" → 500_000_000
+      "3000"  → 3000
+      None    → None
+    """
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+    multipliers = [
+        (r"(?i)^([0-9]*\.?[0-9]+)\s*[Gg][Bb][Pp]?$", 1_000_000_000),
+        (r"(?i)^([0-9]*\.?[0-9]+)\s*[Gg][Bb]?$",      1_000_000_000),
+        (r"(?i)^([0-9]*\.?[0-9]+)\s*[Mm][Bb][Pp]?$",  1_000_000),
+        (r"(?i)^([0-9]*\.?[0-9]+)\s*[Mm][Bb]?$",       1_000_000),
+        (r"(?i)^([0-9]*\.?[0-9]+)\s*[Kk][Bb][Pp]?$",  1_000),
+        (r"(?i)^([0-9]*\.?[0-9]+)\s*[Kk][Bb]?$",       1_000),
+    ]
+    for pat, mult in multipliers:
+        m = re.fullmatch(pat, s)
+        if m:
+            return int(float(m.group(1)) * mult)
+    # Plain integer or float (treated as bp)
+    try:
+        return int(float(s))
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"Cannot parse genome size {s!r}. "
+            "Use a plain integer (bp) or a value with suffix k/kb/kbp, m/mb/mbp, g/gb/gbp."
+        )
+
 
 def _to_int(x: Any) -> Optional[int]:
     try:
@@ -823,7 +872,11 @@ def load_records(path: Optional[Union[str, Path]], source: str, logger: Any = No
 
     return out
 
-def build_output_table(clusters: List[EventCluster]) -> pd.DataFrame:
+def build_output_table(
+    clusters: List[EventCluster],
+    ref_size_bp: Optional[int] = None,
+    mod_size_bp: Optional[int] = None,
+) -> pd.DataFrame:
     rows = []
     counters = {k: 0 for k in TAB_BY_TYPE}
 
@@ -924,6 +977,17 @@ def build_output_table(clusters: List[EventCluster]) -> pd.DataFrame:
                 overlap_end = min(member_ends) if member_ends else c.end
 
             event_length_bp = np.nan
+        # Percentage of genome columns (NaN when genome size or event length is unknown)
+        if ref_size_bp and pd.notna(event_length_bp) and ref_size_bp > 0:
+            pct_of_ref = (event_length_bp / ref_size_bp) * 100
+        else:
+            pct_of_ref = np.nan
+
+        if mod_size_bp and pd.notna(event_length_bp) and mod_size_bp > 0:
+            pct_of_mod = (event_length_bp / mod_size_bp) * 100
+        else:
+            pct_of_mod = np.nan
+
         row = {
             "event_id": eid,
             "chrom": c.chrom,
@@ -931,6 +995,8 @@ def build_output_table(clusters: List[EventCluster]) -> pd.DataFrame:
             "event_start": overlap_start,
             "event_end": overlap_end,
             "event_length_bp": event_length_bp,
+            "pct_of_ref_genome": pct_of_ref,
+            "pct_of_mod_genome": pct_of_mod,
 
             "asm_start": asm.start if asm else np.nan,
             "asm_end": asm.end if asm else np.nan,
@@ -1191,7 +1257,31 @@ def main() -> None:
         default=0,
         help="Tolerance in bp for linking near-identical final event coordinates in linked_event. Default 0 keeps overlap-only linking.",
     )
+    p.add_argument(
+        "--ref_size",
+        default=None,
+        metavar="SIZE",
+        help=(
+            "Size of the reference genome (e.g. 4Gbp, 2.7G, 500Mb, 3000000000). "
+            "When provided, a pct_of_ref_genome column is added to each output CSV "
+            "showing event_length_bp as a percentage of this value."
+        ),
+    )
+    p.add_argument(
+        "--mod_size",
+        default=None,
+        metavar="SIZE",
+        help=(
+            "Size of the modified genome or assembly (e.g. 4.5Gbp, 2.8G, 510Mb). "
+            "When provided, a pct_of_mod_genome column is added to each output CSV "
+            "showing event_length_bp as a percentage of this value."
+        ),
+    )
+
     args = p.parse_args()
+
+    ref_size_bp = _parse_genome_size(args.ref_size)
+    mod_size_bp = _parse_genome_size(args.mod_size)
 
     logger, log_path = setup_logging()
     logger.info(
@@ -1199,6 +1289,8 @@ def main() -> None:
         output_dir=str(args.out),
         tol=args.tol,
         cross_type_tol=args.cross_type_tol,
+        ref_size_bp=ref_size_bp,
+        mod_size_bp=mod_size_bp,
         inputs=_clean_dict(
             {
                 "asm": args.asm,
@@ -1252,7 +1344,7 @@ def main() -> None:
     if not clusters:
         df = pd.DataFrame()
     else:
-        df = build_output_table(clusters)
+        df = build_output_table(clusters, ref_size_bp=ref_size_bp, mod_size_bp=mod_size_bp)
 
     if "long_ont_info_svtype" in df.columns:
         mask = df["long_ont_info_svtype"].notna() & (df["long_ont_info_svtype"] != "")


### PR DESCRIPTION
- Added optional `--ref_size` and `--mod_size` args to `modules/utils/create_sv_output.py`
- Final tables report `pct_of_ref_genome` and `pct_of_mod_genome`, when args are provided. Empty otherwise