### PR TITLE
EFSA-306: freebayes ploidy nfx

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -64,7 +64,7 @@ EUPL-1.2 is a copyleft license. Its Appendix explicitly lists compatible license
 |---|---|---|---|
 | FastQC | 0.11.9 | GPL-3.0-or-later | https://github.com/s-andrews/FastQC |
 | MultiQC | 1.33 | GPL-3.0-or-later | https://github.com/MultiQC/MultiQC |
-| mosdepth | 0.3.12 | MIT | https://github.com/brentp/mosdepth |
+| mosdepth | 0.3.11 | MIT | https://github.com/brentp/mosdepth |
 
 ### Read Processing
 
@@ -140,13 +140,16 @@ EUPL-1.2 is a copyleft license. Its Appendix explicitly lists compatible license
 | broadinstitute/picard | 3.4.0@sha256:dda3ad26... | https://hub.docker.com/r/broadinstitute/picard |
 | dellytools/delly | v1.7.3@sha256:045aba10... | https://github.com/dellytools/delly |
 | ecomolegmo/cutesv | v1.0.4@sha256:9c29e67b... | Internal build (based on cuteSV MIT) |
-| ecomolegmo/debreak | v1.0.3@sha256:f2d8f9b5... | Internal build (based on DeBreak MIT) |
+| ecomolegmo/debreak | v1.0.4@sha256:d3d0737... | Internal build (based on DeBreak MIT) |
+| ecomolegmo/gffread | v0.12.7@sha256:dad98757... | Internal build (based on gffread MIT); copied into the validation image |
 | ecomolegmo/minimap2 | v2.30@sha256:50d38b71... | Internal build (based on minimap2 MIT) |
+| ecomolegmo/mosdepth | 0.3.11@sha256:b24676b8... | Internal build (based on mosdepth MIT) |
+| ecomolegmo/pbzip2 | v1.1.13@sha256:4a308661... | Internal build (based on pbzip2 BSD-3-Clause); copied into the validation image |
 | ecomolegmo/sniffles | v1.0.3@sha256:d3875e4e... | Internal build (based on Sniffles MIT) |
 | ecomolegmo/survivor | v1.0.3@sha256:90263d6b... | Internal build (based on SURVIVOR MIT) |
 | ecomolegmo/syri | v1.0.4@sha256:789d5cdf... | Internal build (based on SyRI MIT) |
-| ecomolegmo/mosdepth | v1.0.1@sha256:802cc917... | Internal build (based on Mosdepth GPL-3.0) |
 | ecomolegmo/trimgalore | v1.0.1@sha256:802cc917... | Internal build (based on TrimGalore GPL-3.0) |
+| ecomolegmo/validation | v1.0.12@sha256:aae33bd4... | Internal validation/runtime support image |
 
 ---
 
@@ -166,5 +169,5 @@ Full license texts for each component are available at their respective source U
 
 ---
 
-*Last updated: 2026-03-29*
+*Last updated: 2026-06-13*
 *Generated from Nextflow config, Dockerfiles, and requirements.txt in the efsa_pipeline repository.*

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -149,7 +149,7 @@ EUPL-1.2 is a copyleft license. Its Appendix explicitly lists compatible license
 | ecomolegmo/survivor | v1.0.3@sha256:90263d6b... | Internal build (based on SURVIVOR MIT) |
 | ecomolegmo/syri | v1.0.4@sha256:789d5cdf... | Internal build (based on SyRI MIT) |
 | ecomolegmo/trimgalore | v1.0.1@sha256:802cc917... | Internal build (based on TrimGalore GPL-3.0) |
-| ecomolegmo/validation | v1.0.12@sha256:aae33bd4... | Internal validation/runtime support image |
+| ecomolegmo/validation | v1.0.13@sha256:0709076d... | Internal validation/runtime support image |
 
 ---
 

--- a/data/inputs/config_template.json
+++ b/data/inputs/config_template.json
@@ -24,13 +24,13 @@
   "reads": [
     {
       "filename": "TBA",
-      "ngs_type": "illumina/pacbio/ont",
+      "ngs_type": "illumina/pacbio-hifi/pacbio-clr/ont",
       "validation_level": "strict/trust/minimal",
       "threads": 8
     },
     {
       "directory": "TBA",
-      "ngs_type": "illumina/pacbio/ont",
+      "ngs_type": "illumina/pacbio-hifi/pacbio-clr/ont",
       "validation_level": "strict/trust/minimal",
       "threads": 8
     }

--- a/docs/getting-started/docker-setup.md
+++ b/docs/getting-started/docker-setup.md
@@ -2,6 +2,8 @@
 
 This guide shows you how to run the EFSA Pipeline in a Docker container with access to input/output folders.
 
+This container is the pipeline runtime environment built from the root `Dockerfile`. Individual bioinformatics and validation steps still run in their own pinned tool images through Nextflow, as configured in `nextflow.config`.
+
 ## Prerequisites
 
 - Docker installed on your system

--- a/docs/nextflow/configuration.md
+++ b/docs/nextflow/configuration.md
@@ -24,7 +24,7 @@ As a result, operational runtime messages are primarily captured in `data/output
 | `cleanup` | `true` | Enables end-of-run cleanup hooks (for example, work directory cleanup) |
 | `validation_level` | `null` | Validation depth: `STRICT`, `TRUST`, or `MINIMAL` — `null` means not forwarded; `config.json` governs |
 | `logging_level` | `null` | Log verbosity: `DEBUG`, `INFO`, `WARNING`, or `ERROR` — `null` means not forwarded; `config.json` governs |
-| `organism_type` | `null` | Organism type: `PROKARYOTE` or `EUKARYOTE` — `null` means not forwarded; `config.json` governs |
+| `organism_type` | `null` | Organism type: `prokaryote` or `eukaryote` — `null` means not forwarded; `config.json` governs. The validated value is written to `validated_params.json` and used to derive FreeBayes ploidy. |
 | `force_defragment_ref` | `false` | Force reference defragmentation — unsupported workaround, use with caution |
 | `help` | `false` | Print help message and exit |
 
@@ -42,6 +42,17 @@ For options shared between Nextflow and `config.json` (`validation_level`, `logg
 When a param is `null` in `nextflow.config`, the flag is not forwarded to the validation script at all, so `config.json` has full control. A `WARNING` is logged whenever a per-file setting overrides a global `config.json` option.
 
 > `threads` follows the same hierarchy but is not exposed as a Nextflow CLI flag — set it only inside `config.json`.
+
+### Derived Analysis Parameters
+
+The workflow derives FreeBayes ploidy from the validated `organism_type` instead of exposing ploidy as a separate user parameter:
+
+| `organism_type` in `validated_params.json` | Derived FreeBayes argument |
+|--------------------------------------------|----------------------------|
+| `prokaryote` | `--ploidy 1` |
+| `eukaryote` | `--ploidy 2` |
+
+See [Tool Parameter Reference](tool-parameters.md#freebayes-variant-calling) for the full FreeBayes command and rationale.
 
 ## Per-Process Configuration
 

--- a/docs/nextflow/running-pipeline.md
+++ b/docs/nextflow/running-pipeline.md
@@ -59,7 +59,7 @@ NXF_QUIET=false nextflow run main.nf --max_cpu $(nproc)
 | `--max_cpu <n>` | Maximum CPUs per process (default: `1`) |
 | `--validation_level <level>` | Validation depth: `STRICT`, `TRUST`, or `MINIMAL` — overridden by `config.json` when set there |
 | `--logging_level <level>` | Log verbosity: `DEBUG`, `INFO`, `WARNING`, or `ERROR` — overridden by `config.json` when set there |
-| `--organism_type <type>` | Organism type: `PROKARYOTE` or `EUKARYOTE` — overridden by `config.json` when set there |
+| `--organism_type <type>` | Organism type: `prokaryote` or `eukaryote` — overridden by `config.json` when set there. The validated value determines FreeBayes ploidy (`1` for prokaryote, `2` for eukaryote). |
 | `--force_defragment_ref` | Force reference defragmentation — unsupported workaround |
 | `--help` | Print help message and exit |
 

--- a/docs/nextflow/running-pipeline.md
+++ b/docs/nextflow/running-pipeline.md
@@ -19,7 +19,7 @@ nextflow run main.nf --max_cpu $(nproc)
 
 This first validates input data from `data/inputs/config.json`, then automatically runs eligible processing workflows (short-read, long-read, ref-vs-mod comparison) based on the validated inputs.
 
-`mod_fasta` is optional after validation. If no validated modified FASTA is present, the pipeline runs in reference-only mode and skips modified-genome mapping/comparison branches.
+Modified-genome mapping and reference-vs-modified comparison branches require a validated modified FASTA (`mod_fasta_validated`). Branches that are disabled by validation do not run, but enabled modified-genome branches expect this file to be present.
 
 Validated files are produced by the `validate` process and passed directly to downstream workflows through channels. A `validated_params.json` file is also emitted for runtime consumption. See the [Validation Overview](../validation/OVERVIEW.md) for details on what this file contains.
 

--- a/docs/nextflow/runtime-messages.md
+++ b/docs/nextflow/runtime-messages.md
@@ -16,7 +16,7 @@ When the pipeline is running, `nextflow.log` contains messages like:
 ```
 
 These messages help track execution order for whichever branches are enabled by validated inputs.
-If `mod_fasta` is missing, modified-genome branches are skipped and reference-only branches continue.
+Modified-genome branches are expected only when validation provides the required modified FASTA and enables the corresponding workflow branch.
 
 ## Unmapped Reads Statistics
 

--- a/docs/nextflow/subworkflows.md
+++ b/docs/nextflow/subworkflows.md
@@ -65,8 +65,10 @@ Read alignment for PacBio or ONT long reads.
 | Sort | samtools sort | 1.23 | MIT |
 | BAM indexing | samtools index | 1.23 | MIT |
 
-**Takes:** `fastqs`, `fasta`, `mapping_tag`, `out_folder_name`
+**Takes:** `fastqs`, `fasta`, `mapping_tag`, `out_folder_name`, `read_type`
 **Emits:** `indexed_bam` — sorted + indexed BAM channel
+
+`read_type` is the validated long-read type. For PacBio HiFi reads, it switches minimap2 from the generic PacBio preset (`map-pb`) to `map-hifi`; PacBio CLR and ONT runs use the mapping tag supplied by the calling workflow.
 
 ---
 
@@ -83,8 +85,10 @@ Structural variant calling from long-read alignments using three callers, with c
 | Consensus merge | SURVIVOR | 1.0.7 | MIT |
 | VCF stats | bcftools stats | 1.23 | MIT |
 
-**Takes:** `fasta`, `fai`, `indexed_bam`, `mapping_tag`, `out_folder_name`
+**Takes:** `fasta`, `fai`, `indexed_bam`, `mapping_tag`, `out_folder_name`, `read_type`
 **Emits:** `merged_vcf` — SURVIVOR-merged VCF channel, `supp_reads` — supporting reads TSV channel
+
+`read_type` selects the cuteSV parameter profile for `pacbio-hifi`, `pacbio-clr`, or `ont`.
 
 ## How Subworkflows Are Used
 
@@ -99,6 +103,6 @@ sv(fasta, mapping.out.indexed_bam, out_folder)
 
 ```groovy
 // In long_read.nf
-mapping_long(fastqs, fasta, mapping_tag, out_folder)
-sv_long(fasta, fai, mapping_long.out.indexed_bam, mapping_tag, out_folder)
+mapping_long(fastqs, fasta, mapping_tag, out_folder, read_type)
+sv_long(fasta, fai, mapping_long.out.indexed_bam, mapping_tag, out_folder, read_type)
 ```

--- a/docs/nextflow/tool-parameters.md
+++ b/docs/nextflow/tool-parameters.md
@@ -1,6 +1,6 @@
 # Tool Parameter Reference
 
-This page documents the hardcoded analysis parameters used by the pipeline's bioinformatics tools. The pipeline supports both **prokaryotic** and **eukaryotic** genomes (set via the `type` field in `config.json`). The current parameter values are suitable for both organism types under typical sequencing conditions.
+This page documents the hardcoded and automatically derived analysis parameters used by the pipeline's bioinformatics tools. The pipeline supports both **prokaryotic** and **eukaryotic** genomes. Validation writes the normalized organism type to `validated_params.json` as `organism_type`, and downstream Nextflow processes consume that value.
 
 ---
 
@@ -11,17 +11,25 @@ This page documents the hardcoded analysis parameters used by the pipeline's bio
 **Module:** `modules/variant_calling.nf`
 
 ```bash
-freebayes -f <ref> --min-coverage 10 --min-base-quality 20 --min-mapping-quality 30 --min-alternate-count 3 <bam>
+freebayes -f <ref> --ploidy <1|2> --min-coverage 10 --min-base-quality 20 --min-mapping-quality 30 --min-alternate-count 3 <bam>
 ```
 
 | Parameter | Value | Freebayes Default | Description |
 |-----------|-------|-------------------|-------------|
+| `--ploidy` | Derived from `organism_type`: `1` for `prokaryote`, `2` for `eukaryote` | 2 | Sample ploidy used by FreeBayes. The value is not user-supplied directly; it is derived from the validated organism type and passed through the short-read workflow to FreeBayes. |
 | `--min-coverage` | 10 | 0 | Minimum number of reads covering a locus to call a variant. The default (0) would attempt calls at sites with a single read, producing many false positives. A value of 10 is a standard threshold for reliable variant calling with moderate Illumina coverage. |
 | `--min-base-quality` | 20 | 0 | Minimum per-base Phred quality score. Q20 (99% per-base accuracy) is the widely accepted quality floor for Illumina data. The default (0) would include low-confidence bases, significantly increasing error-driven false calls. |
 | `--min-mapping-quality` | 30 | 1 | Minimum read mapping Phred score. Q30 (99.9% mapping confidence) ensures only confidently placed reads contribute to variant calls. The default (1) would include multi-mapped and ambiguously placed reads, which is problematic in repetitive regions of both prokaryotic and eukaryotic genomes. |
 | `--min-alternate-count` | 3 | 2 | Minimum number of reads supporting the alternate allele. Slightly stricter than the default (2), providing an additional guard against sequencing-error-driven false positives. |
 
-**Rationale:** These are standard community thresholds for calling SNPs and small indels with moderate Illumina coverage (30–100×). Each value departs from the freebayes default to reduce false positives — particularly important in a regulatory/safety context (GMO assessment). The freebayes defaults are intentionally permissive to support diverse use cases (e.g., low-frequency somatic variants); for GMO detection pipelines these permissive defaults would produce excessive noise.
+**Ploidy derivation:** The validated `organism_type` controls the ploidy passed to FreeBayes:
+
+| `organism_type` | FreeBayes `--ploidy` |
+|-----------------|----------------------|
+| `prokaryote` | `1` |
+| `eukaryote` | `2` |
+
+**Rationale:** `--ploidy 1` matches haploid prokaryotic variant calling, while `--ploidy 2` matches diploid eukaryotic calling. The remaining thresholds are standard community thresholds for calling SNPs and small indels with moderate Illumina coverage (30–100×). Each value departs from the freebayes default to reduce false positives — particularly important in a regulatory/safety context (GMO assessment). The freebayes defaults are intentionally permissive to support diverse use cases (e.g., low-frequency somatic variants); for GMO detection pipelines these permissive defaults would produce excessive noise.
 
 **Trade-offs:**
 
@@ -139,7 +147,7 @@ delta-filter -m -i 90 -l 100 <delta>
 
 | Tool | Pipeline | Module | Key Non-Default Parameters |
 |------|----------|--------|---------------------------|
-| Freebayes | Short-read | `variant_calling.nf` | `--min-coverage 10`, `--min-base-quality 20`, `--min-mapping-quality 30`, `--min-alternate-count 3` |
+| Freebayes | Short-read | `variant_calling.nf` | `--ploidy 1` for `prokaryote` or `--ploidy 2` for `eukaryote`, `--min-coverage 10`, `--min-base-quality 20`, `--min-mapping-quality 30`, `--min-alternate-count 3` |
 | Delly | Short-read | `sv_calling.nf` | Defaults only |
 | cuteSV | Long-read | `sv_calling.nf` | `-t ${task.cpus}` |
 | Sniffles | Long-read | `sv_calling.nf` | Defaults only |

--- a/docs/nextflow/tool-parameters.md
+++ b/docs/nextflow/tool-parameters.md
@@ -47,14 +47,22 @@ All parameters use Delly defaults. No custom thresholds are applied.
 **Module:** `modules/sv_calling.nf`
 
 ```bash
-cuteSV <bam> <ref> <out.vcf> <work_dir> -t ${task.cpus}
+cuteSV <bam> <ref> <out.vcf> <work_dir> -t ${task.cpus} <read-type-specific args>
 ```
 
 | Parameter | Value | Description |
 |-----------|-------|-------------|
 | `-t` | `${task.cpus}` | Number of threads assigned by Nextflow for this task (bounded by process-level CPU limits in `nextflow.config`). |
 
-All other parameters use cuteSV defaults (minimum SV size 50 bp, minimum support 10 reads, etc.). These defaults are suitable for moderate-coverage PacBio/ONT data on both prokaryotic and eukaryotic genomes.
+The pipeline also applies a read-type-specific cuteSV profile based on the validated long-read type:
+
+| Read type | Additional cuteSV parameters |
+|-----------|------------------------------|
+| `pacbio-clr` | `--max_cluster_bias_INS 100 --diff_ratio_merging_INS 0.3 --max_cluster_bias_DEL 200 --diff_ratio_merging_DEL 0.5` |
+| `pacbio-hifi` | `--max_cluster_bias_INS 1000 --diff_ratio_merging_INS 0.9 --max_cluster_bias_DEL 1000 --diff_ratio_merging_DEL 0.5` |
+| `ont` | `--max_cluster_bias_INS 100 --diff_ratio_merging_INS 0.3 --max_cluster_bias_DEL 100 --diff_ratio_merging_DEL 0.3` |
+
+Any other cuteSV parameters use tool defaults.
 
 
 ### Sniffles (structural variant calling)
@@ -68,14 +76,20 @@ All parameters use Sniffles defaults. No custom thresholds are applied.
 **Module:** `modules/sv_calling.nf`
 
 ```bash
-debreak --bam <bam> -r <ref> -o <out_dir> -t ${task.cpus}
+debreak --bam <bam> -o <out_dir> -t ${task.cpus} --rescue_large_ins --rescue_dup --poa --ref <ref>
 ```
 
 | Parameter | Value | Description |
 |-----------|-------|-------------|
+| `--bam` | `<bam>` | Sorted and indexed long-read alignment BAM from the mapping workflow. |
+| `-o` | `<out_dir>` | Output directory for DeBreak results. The pipeline writes to `debreak_out`. |
 | `-t` | `${task.cpus}` | Number of threads assigned by Nextflow for this task (bounded by process-level CPU limits in `nextflow.config`). |
+| `--rescue_large_ins` | *(flag)* | Enables DeBreak rescue logic for large insertion calls. |
+| `--rescue_dup` | *(flag)* | Enables DeBreak rescue logic for duplication calls. |
+| `--poa` | *(flag)* | Enables partial order alignment refinement. |
+| `--ref` | `<ref>` | Reference FASTA used for DeBreak calling and refinement. |
 
-All other parameters use DeBreak defaults.
+Any other DeBreak parameters use tool defaults.
 
 ---
 

--- a/docs/nextflow/validation-nextflow-integration.md
+++ b/docs/nextflow/validation-nextflow-integration.md
@@ -15,7 +15,7 @@ At the moment, integration is done through a **JSON handoff**:
 ## Where It Happens
 
 - Validation process definition: `modules/validate.nf`
-- Validation entrypoint script: `validation.sh` is within the pinned `ecomolegmo/validation` image defined in `nextflow.config` (`v1.0.12` at the time of writing)
+- Validation entrypoint script: `validation.sh` is within the pinned `ecomolegmo/validation` image defined in `nextflow.config` (`v1.0.13`)
 - JSON handoff artifact: `validated_params.json`
 - Consumer side (Nextflow): analysis workflow that parses the JSON and maps values into pipeline logic
 

--- a/docs/nextflow/validation-nextflow-integration.md
+++ b/docs/nextflow/validation-nextflow-integration.md
@@ -15,7 +15,7 @@ At the moment, integration is done through a **JSON handoff**:
 ## Where It Happens
 
 - Validation process definition: `modules/validate.nf`
-- Validation entrypoint script: `validation.sh` is within the `ecomolegmo/validation:1.0.6` image
+- Validation entrypoint script: `validation.sh` is within the pinned `ecomolegmo/validation` image defined in `nextflow.config` (`v1.0.12` at the time of writing)
 - JSON handoff artifact: `validated_params.json`
 - Consumer side (Nextflow): analysis workflow that parses the JSON and maps values into pipeline logic
 
@@ -35,6 +35,8 @@ Because the integration is JSON parsing based:
 - Field names and structure in `validated_params.json` are part of a de facto interface contract.
 - Any schema change on the validation side must be reflected in the Nextflow parsing/consumption logic.
 - Backward compatibility depends on keeping that JSON contract stable or versioned.
+- PacBio chemistry is handed off as `pacbio_read_type` (`pacbio-hifi` or `pacbio-clr`) and drives PacBio-specific minimap2/cuteSV behavior.
+- ONT does not use a separate `ont_read_type` field in Nextflow; when `run_nanopore` is true, downstream long-read processes receive `ont`.
 
 ## Genome-size handoff for SV percentage columns
 

--- a/docs/project/third-party-licenses.md
+++ b/docs/project/third-party-licenses.md
@@ -150,7 +150,7 @@ EUPL-1.2 is a copyleft license. Its Appendix explicitly lists compatible license
 | ecomolegmo/survivor | v1.0.3@sha256:90263d6b... | Internal build (based on SURVIVOR MIT) |
 | ecomolegmo/syri | v1.0.4@sha256:789d5cdf... | Internal build (based on SyRI MIT) |
 | ecomolegmo/trimgalore | v1.0.1@sha256:802cc917... | Internal build (based on TrimGalore GPL-3.0) |
-| ecomolegmo/validation | v1.0.12@sha256:aae33bd4... | Internal validation/runtime support image |
+| ecomolegmo/validation | v1.0.13@sha256:0709076d... | Internal validation/runtime support image |
 
 ---
 

--- a/docs/project/third-party-licenses.md
+++ b/docs/project/third-party-licenses.md
@@ -65,7 +65,7 @@ EUPL-1.2 is a copyleft license. Its Appendix explicitly lists compatible license
 |---|---|---|---|
 | FastQC | 0.11.9 | GPL-3.0-or-later | https://github.com/s-andrews/FastQC |
 | MultiQC | 1.33 | GPL-3.0-or-later | https://github.com/MultiQC/MultiQC |
-| mosdepth | 0.3.12 | MIT | https://github.com/brentp/mosdepth |
+| mosdepth | 0.3.11 | MIT | https://github.com/brentp/mosdepth |
 
 ### Read Processing
 
@@ -141,13 +141,16 @@ EUPL-1.2 is a copyleft license. Its Appendix explicitly lists compatible license
 | broadinstitute/picard | 3.4.0@sha256:dda3ad26... | https://hub.docker.com/r/broadinstitute/picard |
 | dellytools/delly | v1.7.3@sha256:045aba10... | https://github.com/dellytools/delly |
 | ecomolegmo/cutesv | v1.0.4@sha256:9c29e67b... | Internal build (based on cuteSV MIT) |
-| ecomolegmo/debreak | v1.0.3@sha256:f2d8f9b5... | Internal build (based on DeBreak MIT) |
+| ecomolegmo/debreak | v1.0.4@sha256:d3d0737... | Internal build (based on DeBreak MIT) |
+| ecomolegmo/gffread | v0.12.7@sha256:dad98757... | Internal build (based on gffread MIT); copied into the validation image |
 | ecomolegmo/minimap2 | v2.30@sha256:50d38b71... | Internal build (based on minimap2 MIT) |
+| ecomolegmo/mosdepth | 0.3.11@sha256:b24676b8... | Internal build (based on mosdepth MIT) |
+| ecomolegmo/pbzip2 | v1.1.13@sha256:4a308661... | Internal build (based on pbzip2 BSD-3-Clause); copied into the validation image |
 | ecomolegmo/sniffles | v1.0.3@sha256:d3875e4e... | Internal build (based on Sniffles MIT) |
 | ecomolegmo/survivor | v1.0.3@sha256:90263d6b... | Internal build (based on SURVIVOR MIT) |
 | ecomolegmo/syri | v1.0.4@sha256:789d5cdf... | Internal build (based on SyRI MIT) |
-| ecomolegmo/mosdepth | v1.0.1@sha256:802cc917... | Internal build (based on Mosdepth GPL-3.0) |
 | ecomolegmo/trimgalore | v1.0.1@sha256:802cc917... | Internal build (based on TrimGalore GPL-3.0) |
+| ecomolegmo/validation | v1.0.12@sha256:aae33bd4... | Internal validation/runtime support image |
 
 ---
 
@@ -167,5 +170,5 @@ Full license texts for each component are available at their respective source U
 
 ---
 
-*Last updated: 2026-03-29*
+*Last updated: 2026-06-13*
 *Generated from Nextflow config, Dockerfiles, and requirements.txt in the efsa_pipeline repository.*

--- a/docs/validation/CONFIG_GUIDE.md
+++ b/docs/validation/CONFIG_GUIDE.md
@@ -182,8 +182,6 @@ All files in the directory inherit the same settings. Each file becomes a separa
 | `"pacbio-hifi"` | PacBio HiFi (CCS) long reads | 10-25 kb |
 | `"pacbio-clr"` | PacBio CLR long reads | 10-50+ kb |
 
-> **Note:** Plain `"pacbio"` is no longer accepted. You must specify either `"pacbio-hifi"` or `"pacbio-clr"`. Mixing both types in a single run is not allowed. Both types use the same Nextflow workflow path but different SV-calling parameters tuned for each chemistry.
-
 ### FeatureConfig Object
 
 Specifies feature annotation files (BED, GFF, GTF).

--- a/docs/validation/CONFIG_GUIDE.md
+++ b/docs/validation/CONFIG_GUIDE.md
@@ -161,7 +161,7 @@ Specifies sequencing read files. Supports individual files or directories.
 
 #### Option 2: Directory of Files
 
-All files in the directory inherit the same settings. Each file becomes a separate read entry. This works for all NGS types (`illumina`, `ont`, `pacbio`).
+All files in the directory inherit the same settings. Each file becomes a separate read entry. This works for all NGS types (`illumina`, `ont`, `pacbio-hifi`, `pacbio-clr`).
 
 ```json
 "reads": [
@@ -179,9 +179,10 @@ All files in the directory inherit the same settings. Each file becomes a separa
 |-------|-------------|-------------------|
 | `"illumina"` | Illumina short reads (SE or PE) | 50-300 bp |
 | `"ont"` | Oxford Nanopore long reads | 1-100+ kb |
-| `"pacbio"` | PacBio long reads | 10-50+ kb |
+| `"pacbio-hifi"` | PacBio HiFi (CCS) long reads | 10-25 kb |
+| `"pacbio-clr"` | PacBio CLR long reads | 10-50+ kb |
 
-<!-- **Note:** BAM files are automatically detected and converted to FASTQ. Default NGS type for BAM: `pacbio`. -->
+> **Note:** Plain `"pacbio"` is no longer accepted. You must specify either `"pacbio-hifi"` or `"pacbio-clr"`. Mixing both types in a single run is not allowed. Both types use the same Nextflow workflow path but different SV-calling parameters tuned for each chemistry.
 
 ### FeatureConfig Object
 

--- a/docs/validation/OVERVIEW.md
+++ b/docs/validation/OVERVIEW.md
@@ -94,6 +94,7 @@ It is used at runtime by the analysis workflow to determine which pipelines to e
 | `run_illumina`          | boolean | `true` when validated Illumina FASTQ reads are present.                                               |
 | `run_nanopore`          | boolean | `true` when validated Nanopore (ONT) reads are present (FASTQ or BAM).                               |
 | `run_pacbio`            | boolean | `true` when validated PacBio reads are present (FASTQ or BAM).                                       |
+| `pacbio_read_type`      | string  | `"pacbio-hifi"` or `"pacbio-clr"` when `run_pacbio` is `true`; `null` otherwise.                    |
 | `contig_file_size`      | integer | Number of contig files produced by inter-genome characterisation.                                     |
 | `ref_genome_size_bp`    | integer | Validated reference genome size in base pairs, used by `restructure_sv_tbl` to calculate `pct_of_ref_genome`. Omitted when unavailable. |
 | `mod_genome_size_bp`    | integer | Validated modified genome size in base pairs, used by `restructure_sv_tbl` to calculate `pct_of_mod_genome`. Omitted when unavailable. |

--- a/docs/validation/OVERVIEW.md
+++ b/docs/validation/OVERVIEW.md
@@ -95,6 +95,7 @@ It is used at runtime by the analysis workflow to determine which pipelines to e
 | `run_nanopore`          | boolean | `true` when validated Nanopore (ONT) reads are present (FASTQ or BAM).                               |
 | `run_pacbio`            | boolean | `true` when validated PacBio reads are present (FASTQ or BAM).                                       |
 | `pacbio_read_type`      | string  | `"pacbio-hifi"` or `"pacbio-clr"` when `run_pacbio` is `true`; `null` otherwise.                    |
+| `organism_type`         | string  | `"prokaryote"` or `"eukaryote"`, taken from the `type` field in `config.json` options.               |
 | `contig_file_size`      | integer | Number of contig files produced by inter-genome characterisation.                                     |
 | `ref_genome_size_bp`    | integer | Validated reference genome size in base pairs, used by `restructure_sv_tbl` to calculate `pct_of_ref_genome`. Omitted when unavailable. |
 | `mod_genome_size_bp`    | integer | Validated modified genome size in base pairs, used by `restructure_sv_tbl` to calculate `pct_of_mod_genome`. Omitted when unavailable. |

--- a/modules/mapping.nf
+++ b/modules/mapping.nf
@@ -197,14 +197,16 @@ process minimap2 {
     each path(fasta_file)
     val mapping_tag
     val out_folder_name
+    val read_type
 
     output:
     tuple val(pair_id), path("${pair_id}.sam")
     
 
     script:
+    def minimap_preset = read_type == "pacbio-hifi" ? "map-hifi" : mapping_tag
     """
-    minimap2 -t ${task.cpus} -ax $mapping_tag $fasta_file $reads > ${pair_id}.sam
+    minimap2 -t ${task.cpus} -ax ${minimap_preset} $fasta_file $reads > ${pair_id}.sam
     """
 }
 

--- a/modules/mapping.nf
+++ b/modules/mapping.nf
@@ -197,14 +197,14 @@ process minimap2 {
     each path(fasta_file)
     val mapping_tag
     val out_folder_name
-    val read_type
+    val pacbio_read_type
 
     output:
     tuple val(pair_id), path("${pair_id}.sam")
     
 
     script:
-    def minimap_preset = read_type == "pacbio-hifi" ? "map-hifi" : mapping_tag
+    def minimap_preset = pacbio_read_type == "pacbio-hifi" ? "map-hifi" : mapping_tag
     """
     minimap2 -t ${task.cpus} -ax ${minimap_preset} $fasta_file $reads > ${pair_id}.sam
     """

--- a/modules/sv_calling.nf
+++ b/modules/sv_calling.nf
@@ -87,15 +87,24 @@ process cute_sv {
     each path(fai)
     tuple val(pair_id), path(bam_file), path(bam_index) 
     val out_folder_name
+    val read_type
 
     output:
     tuple val(pair_id), path("${pair_id}_cutesv.vcf")
     
 
     script:
+    def cutesv_args = [
+        "pacbio-clr":  "--max_cluster_bias_INS 100 --diff_ratio_merging_INS 0.3 --max_cluster_bias_DEL 200 --diff_ratio_merging_DEL 0.5",
+        "pacbio-hifi": "--max_cluster_bias_INS 1000 --diff_ratio_merging_INS 0.9 --max_cluster_bias_DEL 1000 --diff_ratio_merging_DEL 0.5",
+        "ont":         "--max_cluster_bias_INS 100 --diff_ratio_merging_INS 0.3 --max_cluster_bias_DEL 100 --diff_ratio_merging_DEL 0.3"
+    ][read_type]
+    if (!cutesv_args) {
+        error "Unsupported validated read_type '${read_type}' for CuteSV in ${out_folder_name}. Expected one of: pacbio-hifi, pacbio-clr, ont."
+    }
     """
     mkdir ${pair_id}_out
-    cuteSV $bam_file $fasta_file ${pair_id}_cutesv.vcf ${pair_id}_out -t ${task.cpus}
+    cuteSV $bam_file $fasta_file ${pair_id}_cutesv.vcf ${pair_id}_out -t ${task.cpus} ${cutesv_args}
     """
 }
 
@@ -115,7 +124,7 @@ process debreak {
 
     script:
     """
-    debreak --bam $bam_file -r $fasta_file -o debreak_out -t ${task.cpus}
+    debreak --bam $bam_file -o debreak_out -t ${task.cpus} --rescue_large_ins --rescue_dup --poa --ref $fasta_file
     mv debreak_out/debreak.vcf debreak_out/${pair_id}_debreak.vcf
     """
 }

--- a/modules/validation/CLAUDE.md
+++ b/modules/validation/CLAUDE.md
@@ -165,7 +165,7 @@ Full specification is in `validation-pkg/docs/CONFIG_GUIDE.md`.
     {"filename": "illumina_R1.fastq.gz", "ngs_type": "illumina"},
     {"filename": "illumina_R2.fastq.gz", "ngs_type": "illumina"},
     {"filename": "ont_reads.fastq.gz",   "ngs_type": "ont"},
-    {"filename": "pacbio_reads.bam",     "ngs_type": "pacbio"}
+    {"filename": "pacbio_reads.bam",     "ngs_type": "pacbio-hifi"}
   ],
   "ref_feature_filename": {"filename": "ref.gff3"},
   "mod_feature_filename": {"filename": "mod.gff3"},
@@ -220,7 +220,7 @@ n_sequence_limit : Optional[int]  # default 5; forbidden for plasmid configs
 **`ReadConfig`** (extends `BaseValidatorConfig`)
 ```
 detected_format : ReadFormat    # FASTQ or BAM
-ngs_type        : str           # "illumina", "ont", "pacbio" — validated in __post_init__
+ngs_type        : str           # "illumina", "ont", "pacbio-hifi", "pacbio-clr" — validated in __post_init__
 ```
 
 **`FeatureConfig`** (extends `BaseValidatorConfig`)
@@ -372,10 +372,10 @@ DEBUG, INFO, WARNING, ERROR
 
 ### `NgsType`
 ```
-ILLUMINA, ONT, PACBIO
+ILLUMINA, ONT, PACBIO_HIFI, PACBIO_CLR
 
-.normalize(val)  → NgsType (no default — raises ValueError if None)
-.value           → "illumina" / "ont" / "pacbio"
+.normalize(val)  → NgsType (no default — raises ValueError if None or "pacbio")
+.value           → "illumina" / "ont" / "pacbio-hifi" / "pacbio-clr"
 ```
 
 ---
@@ -545,7 +545,7 @@ output_filename_suffix, output_subdir_name
 input_file, output_file, validation_level, elapsed_time
 base_name                  : str     # filename without R1/R2 suffix
 read_number                : int     # 1 or 2 (0 if not detected)
-ngs_type                   : str     # "illumina", "ont", "pacbio"
+ngs_type                   : str     # "illumina", "ont", "pacbio-hifi", "pacbio-clr"
 illumina_pairing_detected  : str     # "illumina" if R1/R2 pattern matched; else ""
 num_reads                  : int
 
@@ -843,6 +843,7 @@ run_ref_x_mod     : bool = False   # both genomes validated + not fragmented + g
 run_illumina      : bool = False   # illumina reads validated
 run_nanopore      : bool = False   # ont reads validated
 run_pacbio        : bool = False   # pacbio reads validated
+pacbio_read_type  : Optional[str] = None  # "pacbio-hifi" or "pacbio-clr"; null when run_pacbio is False
 contig_file_size  : int  = 0       # len(gxg_metadata['contig_files'])
 validation_timestamp : str = ""    # YYYYMMDD_HHMMSS
 ref_genome_size_bp : Optional[int] = None  # validated reference genome size, bp

--- a/modules/validation/CLAUDE.md
+++ b/modules/validation/CLAUDE.md
@@ -844,6 +844,7 @@ run_illumina      : bool = False   # illumina reads validated
 run_nanopore      : bool = False   # ont reads validated
 run_pacbio        : bool = False   # pacbio reads validated
 pacbio_read_type  : Optional[str] = None  # "pacbio-hifi" or "pacbio-clr"; null when run_pacbio is False
+organism_type     : str  = "prokaryote"  # "prokaryote" or "eukaryote" from config options
 contig_file_size  : int  = 0       # len(gxg_metadata['contig_files'])
 validation_timestamp : str = ""    # YYYYMMDD_HHMMSS
 ref_genome_size_bp : Optional[int] = None  # validated reference genome size, bp
@@ -879,7 +880,7 @@ def _path(meta):
     return value if value and value != "None" else None
 ```
 
-### `build_params(validation_results: dict) → NextflowParams`
+### `build_params(validation_results: dict, run_timestamp: str = None, base_dir: Path = None, organism_type: str = "prokaryote") → NextflowParams`
 Expected keys in `validation_results`:
 ```
 ref_genome    : GenomeOutputMetadata | None

--- a/modules/validation/main.py
+++ b/modules/validation/main.py
@@ -354,7 +354,7 @@ def main():
             "skipped. Feature coordinates are not meaningful on a defragmented reference."
         )
     repo_root = config_path.parent.parent.parent
-    params = nf_params.build_params(validation_results, base_dir=repo_root)
+    params = nf_params.build_params(validation_results, base_dir=repo_root, organism_type=config.type.value)
     nf_params.write_params(params, output_dir / "validated_params.json")
 
     return 0

--- a/modules/validation/utils/nextflow_params_handler.py
+++ b/modules/validation/utils/nextflow_params_handler.py
@@ -16,6 +16,7 @@ general_options (pipeline execution switches):
   run_nanopore         – True when validated Nanopore (ONT) reads are present
   run_pacbio           – True when validated PacBio reads are present
   pacbio_read_type     – "pacbio-hifi" or "pacbio-clr" when run_pacbio is True; null otherwise
+  organism_type        – "prokaryote" or "eukaryote" (from config options; default: "prokaryote")
   contig_file_size     – number of contig files from inter-genome characterisation
   ref_genome_size_bp   – validated reference genome size in base pairs, when available
   mod_genome_size_bp   – validated modified genome size in base pairs, when available
@@ -51,6 +52,7 @@ class NextflowParams:
     run_nanopore: bool = False
     run_pacbio: bool = False
     pacbio_read_type: Optional[str] = None
+    organism_type: str = "prokaryote"
     contig_file_size: int = 0
     validation_timestamp: str = ""
     ref_genome_size_bp: Optional[int] = None
@@ -77,6 +79,7 @@ class NextflowParams:
             "run_nanopore": self.run_nanopore,
             "run_pacbio": self.run_pacbio,
             "pacbio_read_type": self.pacbio_read_type,
+            "organism_type": self.organism_type,
             "contig_file_size": self.contig_file_size,
             "validation_timestamp": self.validation_timestamp,
             "illumina_fastqs": self.illumina_fastqs,
@@ -101,6 +104,7 @@ def build_params(
     validation_results: dict,
     run_timestamp: str = None,
     base_dir: Path = None,
+    organism_type: str = "prokaryote",
 ) -> NextflowParams:
     """
     Build a Nextflow params dataclass from validation results.
@@ -243,6 +247,7 @@ def build_params(
             else "pacbio-clr" if ("pacbio-clr" in fastqs_by_type or "pacbio-clr" in bams_by_type)
             else None
         ),
+        organism_type=organism_type,
         contig_file_size=len(contig_files),
         validation_timestamp=run_timestamp or datetime.now().strftime("%Y%m%d_%H%M%S"),
         ref_genome_size_bp=ref_genome_size_bp,

--- a/modules/validation/utils/nextflow_params_handler.py
+++ b/modules/validation/utils/nextflow_params_handler.py
@@ -15,6 +15,7 @@ general_options (pipeline execution switches):
   run_illumina         – True when validated Illumina reads are present
   run_nanopore         – True when validated Nanopore (ONT) reads are present
   run_pacbio           – True when validated PacBio reads are present
+  pacbio_read_type     – "pacbio-hifi" or "pacbio-clr" when run_pacbio is True; null otherwise
   contig_file_size     – number of contig files from inter-genome characterisation
   ref_genome_size_bp   – validated reference genome size in base pairs, when available
   mod_genome_size_bp   – validated modified genome size in base pairs, when available
@@ -49,6 +50,7 @@ class NextflowParams:
     run_illumina: bool = False
     run_nanopore: bool = False
     run_pacbio: bool = False
+    pacbio_read_type: Optional[str] = None
     contig_file_size: int = 0
     validation_timestamp: str = ""
     ref_genome_size_bp: Optional[int] = None
@@ -74,6 +76,7 @@ class NextflowParams:
             "run_illumina": self.run_illumina,
             "run_nanopore": self.run_nanopore,
             "run_pacbio": self.run_pacbio,
+            "pacbio_read_type": self.pacbio_read_type,
             "contig_file_size": self.contig_file_size,
             "validation_timestamp": self.validation_timestamp,
             "illumina_fastqs": self.illumina_fastqs,
@@ -231,7 +234,15 @@ def build_params(
                        and gxg.get("passed", False)),
         run_illumina="illumina" in fastqs_by_type,
         run_nanopore=("ont" in fastqs_by_type or "ont" in bams_by_type),
-        run_pacbio=("pacbio" in fastqs_by_type or "pacbio" in bams_by_type),
+        run_pacbio=(
+            "pacbio-hifi" in fastqs_by_type or "pacbio-hifi" in bams_by_type
+            or "pacbio-clr" in fastqs_by_type or "pacbio-clr" in bams_by_type
+        ),
+        pacbio_read_type=(
+            "pacbio-hifi" if ("pacbio-hifi" in fastqs_by_type or "pacbio-hifi" in bams_by_type)
+            else "pacbio-clr" if ("pacbio-clr" in fastqs_by_type or "pacbio-clr" in bams_by_type)
+            else None
+        ),
         contig_file_size=len(contig_files),
         validation_timestamp=run_timestamp or datetime.now().strftime("%Y%m%d_%H%M%S"),
         ref_genome_size_bp=ref_genome_size_bp,
@@ -244,8 +255,8 @@ def build_params(
         illumina_fastqs=fastqs_by_type.get("illumina", []),
         ont_fastqs=fastqs_by_type.get("ont", []),
         ont_bams=bams_by_type.get("ont", []),
-        pacbio_fastqs=fastqs_by_type.get("pacbio", []),
-        pacbio_bams=bams_by_type.get("pacbio", []),
+        pacbio_fastqs=fastqs_by_type.get("pacbio-hifi", []) + fastqs_by_type.get("pacbio-clr", []),
+        pacbio_bams=bams_by_type.get("pacbio-hifi", []) + bams_by_type.get("pacbio-clr", []),
         contig_files=contig_files,
     )
 

--- a/modules/validation/utils/tests/test_nextflow_params.py
+++ b/modules/validation/utils/tests/test_nextflow_params.py
@@ -131,71 +131,51 @@ class TestReads:
         r["reads"] = [_meta("/reads/nano.fastq", ngs_type="ont")]
         p = build_params(r)
         assert p.run_nanopore is True
-        assert p.nanopore_fastq == "/reads/nano.fastq"
+        assert "/reads/nano.fastq" in p.ont_fastqs
         assert p.run_illumina is False
 
-    def test_pacbio_read(self):
+    def test_pacbio_hifi_read(self):
         r = _base()
-        r["reads"] = [_meta("/reads/pb.fastq", ngs_type="pacbio")]
+        r["reads"] = [_meta("/reads/pb.fastq", ngs_type="pacbio-hifi")]
         p = build_params(r)
         assert p.run_pacbio is True
-        assert p.pacbio_fastq == "/reads/pb.fastq"
+        assert p.pacbio_read_type == "pacbio-hifi"
+        assert "/reads/pb.fastq" in p.pacbio_fastqs
 
-    def test_no_pacbio_key_when_absent(self):
+    def test_pacbio_clr_read(self):
+        r = _base()
+        r["reads"] = [_meta("/reads/pb.fastq", ngs_type="pacbio-clr")]
+        p = build_params(r)
+        assert p.run_pacbio is True
+        assert p.pacbio_read_type == "pacbio-clr"
+        assert "/reads/pb.fastq" in p.pacbio_fastqs
+
+    def test_pacbio_read_type_null_when_absent(self):
         r = _base()
         r["reads"] = [_meta("/reads/R1.fastq", ngs_type="illumina")]
         p = build_params(r)
-        assert p.pacbio_fastq is None
-
-    def test_multiple_reads_same_type_is_not_supported(self):
-        """Multiple ONT/PacBio files from a directory input must be rejected at config load time."""
-        # build_params itself does not enforce this — the guard lives in ConfigManager.
-        # This test documents that submitting two ONT paths is not a supported use case:
-        # ConfigManager._parse_reads_configs raises ValueError before we ever reach build_params.
-        from validation_pkg.config_manager import ConfigManager
-        with pytest.raises(ValueError, match="Only one ONT or PacBio file"):
-            # Simulate the directory-iteration branch with two ONT files
-            import types, pathlib
-            config_stub = types.SimpleNamespace(
-                config_dir=pathlib.Path("/fake"),
-                output_dir=pathlib.Path("/fake/valid"),
-                options={},
-                reads=[],
-            )
-            read_entry = {"directory": "ont_dir", "ngs_type": "ont"}
-            # Patch iterdir to return two files
-            fake_files = [pathlib.Path("/fake/ont_dir/a.fastq"), pathlib.Path("/fake/ont_dir/b.fastq")]
-            original_iterdir = pathlib.Path.iterdir
-            pathlib.Path.iterdir = lambda self: iter(fake_files)
-            original_exists = pathlib.Path.exists
-            original_is_dir = pathlib.Path.is_dir
-            pathlib.Path.exists = lambda self: True
-            pathlib.Path.is_dir = lambda self: True
-            try:
-                ConfigManager._parse_reads_configs({"reads": [read_entry]}, config_stub)
-            finally:
-                pathlib.Path.iterdir = original_iterdir
-                pathlib.Path.exists = original_exists
-                pathlib.Path.is_dir = original_is_dir
+        assert p.run_pacbio is False
+        assert p.pacbio_read_type is None
 
     def test_mixed_read_types(self):
         r = _base()
         r["reads"] = [
             _meta("/reads/R1.fastq", ngs_type="illumina"),
             _meta("/reads/nano.fastq", ngs_type="ont"),
-            _meta("/reads/pb.fastq", ngs_type="pacbio"),
+            _meta("/reads/pb.fastq", ngs_type="pacbio-hifi"),
         ]
         p = build_params(r)
         assert p.run_illumina is True
         assert p.run_nanopore is True
         assert p.run_pacbio is True
+        assert p.pacbio_read_type == "pacbio-hifi"
 
     def test_no_reads(self):
         p = build_params(_base())
         assert p.run_illumina is False
         assert p.run_nanopore is False
         assert p.run_pacbio is False
-        assert p.nanopore_fastq is None
+        assert p.pacbio_read_type is None
 
 
 # ---------------------------------------------------------------------------
@@ -285,17 +265,6 @@ class TestPlasmidPaths:
 
 
 # ---------------------------------------------------------------------------
-# run_truvari always False
-# ---------------------------------------------------------------------------
-
-class TestRunTruvari:
-
-    def test_always_false(self):
-        p = build_params(_base())
-        assert p.run_truvari is False
-
-
-# ---------------------------------------------------------------------------
 # write_params
 # ---------------------------------------------------------------------------
 
@@ -317,4 +286,22 @@ class TestWriteParams:
             loaded = json.loads(out.read_text())
         assert isinstance(loaded, dict)
         assert "run_ref_x_mod" in loaded
-        assert "run_truvari" in loaded
+        assert "pacbio_read_type" in loaded
+
+    def test_pacbio_read_type_null_when_no_pacbio(self):
+        params = build_params(_base())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "params.json"
+            write_params(params, out)
+            loaded = json.loads(out.read_text())
+        assert loaded["pacbio_read_type"] is None
+
+    def test_pacbio_read_type_set_when_pacbio_present(self):
+        r = _base()
+        r["reads"] = [_meta("/reads/pb.fastq", ngs_type="pacbio-hifi")]
+        params = build_params(r)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "params.json"
+            write_params(params, out)
+            loaded = json.loads(out.read_text())
+        assert loaded["pacbio_read_type"] == "pacbio-hifi"

--- a/modules/validation/utils/tests/test_nextflow_params.py
+++ b/modules/validation/utils/tests/test_nextflow_params.py
@@ -286,6 +286,30 @@ class TestWriteParams:
             loaded = json.loads(out.read_text())
         assert isinstance(loaded, dict)
         assert "run_ref_x_mod" in loaded
+        assert "organism_type" in loaded
+
+
+# ---------------------------------------------------------------------------
+# organism_type
+# ---------------------------------------------------------------------------
+
+class TestOrganismType:
+
+    def test_default_is_prokaryote(self):
+        p = build_params(_base())
+        assert p.organism_type == "prokaryote"
+
+    def test_eukaryote_passed_through(self):
+        p = build_params(_base(), organism_type="eukaryote")
+        assert p.organism_type == "eukaryote"
+
+    def test_organism_type_in_json(self):
+        params = build_params(_base(), organism_type="eukaryote")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "params.json"
+            write_params(params, out)
+            loaded = json.loads(out.read_text())
+        assert loaded["organism_type"] == "eukaryote"
         assert "pacbio_read_type" in loaded
 
     def test_pacbio_read_type_null_when_no_pacbio(self):

--- a/modules/validation/validation-pkg/tests/test_config_manager.py
+++ b/modules/validation/validation-pkg/tests/test_config_manager.py
@@ -457,25 +457,25 @@ class TestConfigManager:
         (temp_dir / "illumina.fastq").write_text("@read1\nATCG\n+\nIIII\n")
         (temp_dir / "ont.fastq").write_text("@read1\nATCG\n+\nIIII\n")
         (temp_dir / "pacbio.fastq").write_text("@read1\nATCG\n+\nIIII\n")
-        
+
         config = {
             "ref_genome_filename": {"filename": "ref.fasta"},
             "mod_genome_filename": {"filename": "mod.fasta"},
             "reads": [
                 {"filename": "illumina.fastq", "ngs_type": "illumina"},
                 {"filename": "ont.fastq", "ngs_type": "ont"},
-                {"filename": "pacbio.fastq", "ngs_type": "pacbio"}
+                {"filename": "pacbio.fastq", "ngs_type": "pacbio-hifi"}
             ]
         }
-        
+
         config_file = temp_dir / "config.json"
         config_file.write_text(json.dumps(config))
-        
+
         loaded_config = ConfigManager.load(str(config_file))
         assert len(loaded_config.reads) == 3
         assert loaded_config.reads[0].ngs_type.value == "illumina"
         assert loaded_config.reads[1].ngs_type.value == "ont"
-        assert loaded_config.reads[2].ngs_type.value == "pacbio"
+        assert loaded_config.reads[2].ngs_type.value == "pacbio-hifi"
         
         # Check all paths are absolute
         assert all(read.filepath.is_absolute() for read in loaded_config.reads)
@@ -1096,14 +1096,33 @@ class TestConfigValidatorSettings:
 
         config = {
             "ref_genome_filename": {"filename": "ref.fasta"},
-            "reads": [{"directory": "pb_reads/", "ngs_type": "pacbio"}]
+            "reads": [{"directory": "pb_reads/", "ngs_type": "pacbio-hifi"}]
         }
         config_file = temp_dir / "config.json"
         config_file.write_text(json.dumps(config, indent=2))
 
         loaded_config = ConfigManager.load(str(config_file))
         assert len(loaded_config.reads) == 2
-        assert all(r.ngs_type.value == "pacbio" for r in loaded_config.reads)
+        assert all(r.ngs_type.value == "pacbio-hifi" for r in loaded_config.reads)
+
+    def test_mixed_pacbio_types_rejected(self, temp_dir):
+        """Mixing pacbio-hifi and pacbio-clr in the same run must raise ValueError."""
+        (temp_dir / "ref.fasta").write_text(">seq1\nATCG\n")
+        (temp_dir / "hifi.fastq").write_text("@read1\nATCG\n+\nIIII\n")
+        (temp_dir / "clr.fastq").write_text("@read1\nATCG\n+\nIIII\n")
+
+        config = {
+            "ref_genome_filename": {"filename": "ref.fasta"},
+            "reads": [
+                {"filename": "hifi.fastq", "ngs_type": "pacbio-hifi"},
+                {"filename": "clr.fastq", "ngs_type": "pacbio-clr"},
+            ]
+        }
+        config_file = temp_dir / "config.json"
+        config_file.write_text(json.dumps(config, indent=2))
+
+        with pytest.raises((ConfigurationError, ValueError), match="Cannot mix pacbio-hifi and pacbio-clr"):
+            ConfigManager.load(str(config_file))
 
     def test_global_and_file_level_options_merge(self, temp_dir):
         """Test that global options and file-level options merge correctly."""

--- a/modules/validation/validation-pkg/tests/test_formats.py
+++ b/modules/validation/validation-pkg/tests/test_formats.py
@@ -523,27 +523,35 @@ class TestNgsType:
     def test_enum_values(self):
         assert NgsType.ILLUMINA.value == "illumina"
         assert NgsType.ONT.value == "ont"
-        assert NgsType.PACBIO.value == "pacbio"
+        assert NgsType.PACBIO_HIFI.value == "pacbio-hifi"
+        assert NgsType.PACBIO_CLR.value == "pacbio-clr"
 
     def test_normalize_exact(self):
         assert NgsType.normalize("illumina") == NgsType.ILLUMINA
         assert NgsType.normalize("ont") == NgsType.ONT
-        assert NgsType.normalize("pacbio") == NgsType.PACBIO
+        assert NgsType.normalize("pacbio-hifi") == NgsType.PACBIO_HIFI
+        assert NgsType.normalize("pacbio-clr") == NgsType.PACBIO_CLR
 
     def test_normalize_uppercase(self):
         assert NgsType.normalize("ILLUMINA") == NgsType.ILLUMINA
         assert NgsType.normalize("ONT") == NgsType.ONT
-        assert NgsType.normalize("PACBIO") == NgsType.PACBIO
+        assert NgsType.normalize("PACBIO-HIFI") == NgsType.PACBIO_HIFI
+        assert NgsType.normalize("PACBIO-CLR") == NgsType.PACBIO_CLR
 
     def test_normalize_mixed_case(self):
         assert NgsType.normalize("Illumina") == NgsType.ILLUMINA
-        assert NgsType.normalize("PacBio") == NgsType.PACBIO
+        assert NgsType.normalize("PacBio-HiFi") == NgsType.PACBIO_HIFI
+        assert NgsType.normalize("PacBio-CLR") == NgsType.PACBIO_CLR
 
     def test_normalize_strips_whitespace(self):
         assert NgsType.normalize("  ont  ") == NgsType.ONT
 
     def test_normalize_enum_instance_passthrough(self):
-        assert NgsType.normalize(NgsType.PACBIO) == NgsType.PACBIO
+        assert NgsType.normalize(NgsType.PACBIO_HIFI) == NgsType.PACBIO_HIFI
+
+    def test_normalize_plain_pacbio_raises(self):
+        with pytest.raises(ValueError, match="is not a valid NgsType"):
+            NgsType.normalize("pacbio")
 
     def test_normalize_invalid_raises(self):
         with pytest.raises(ValueError, match="is not a valid NgsType"):

--- a/modules/validation/validation-pkg/tests/test_read_validator.py
+++ b/modules/validation/validation-pkg/tests/test_read_validator.py
@@ -650,13 +650,31 @@ class TestReadValidatorNGSTypes:
 
         assert len(validator.sequences) == 1
 
-    def test_pacbio_reads(self, simple_fastq, output_dir):
-        """Test processing PacBio reads."""
+    def test_pacbio_hifi_reads(self, simple_fastq, output_dir):
+        """Test processing PacBio HiFi reads."""
         read_config = ReadConfig(
             filename="reads.fastq",
             basename="reads",
             filepath=simple_fastq,
-            ngs_type="pacbio",
+            ngs_type="pacbio-hifi",
+            coding_type=CT.NONE,
+            detected_format=ReadFormat.FASTQ,
+            output_dir=output_dir,
+            global_options={}
+        )
+
+        validator = ReadValidator(read_config, ReadValidator.Settings())
+        validator.run()
+
+        assert len(validator.sequences) == 1
+
+    def test_pacbio_clr_reads(self, simple_fastq, output_dir):
+        """Test processing PacBio CLR reads."""
+        read_config = ReadConfig(
+            filename="reads.fastq",
+            basename="reads",
+            filepath=simple_fastq,
+            ngs_type="pacbio-clr",
             coding_type=CT.NONE,
             detected_format=ReadFormat.FASTQ,
             output_dir=output_dir,

--- a/modules/validation/validation-pkg/validation_pkg/config_manager.py
+++ b/modules/validation/validation-pkg/validation_pkg/config_manager.py
@@ -424,6 +424,16 @@ class ConfigManager:
             except ValueError as e:
                 raise ValueError(f"Invalid reads[{idx}]: {e}")
 
+        pacbio_types_present = {
+            r.ngs_type.value for r in config.reads
+            if r.ngs_type is not None and r.ngs_type.value in ("pacbio-hifi", "pacbio-clr")
+        }
+        if len(pacbio_types_present) > 1:
+            raise ValueError(
+                "Cannot mix pacbio-hifi and pacbio-clr reads in the same run. "
+                f"Found: {', '.join(sorted(pacbio_types_present))}"
+            )
+
     @staticmethod
     def _parse_read_config(value: Any, field_name: str, config_dir: Path, output_dir: Path, global_options: Dict[str, Any] = None) -> ReadConfig:
         """Parse a read configuration entry."""

--- a/modules/validation/validation-pkg/validation_pkg/docs/API_REFERENCE.md
+++ b/modules/validation/validation-pkg/validation_pkg/docs/API_REFERENCE.md
@@ -288,7 +288,7 @@ Configuration for sequencing read files.
 - `filename` (str): Original filename
 - `filepath` (Path): Absolute resolved path
 - `basename` (str): Filename without extension
-- `ngs_type` (str): Sequencing platform ("illumina", "ont", or "pacbio")
+- `ngs_type` (str): Sequencing platform ("illumina", "ont", "pacbio-hifi", or "pacbio-clr")
 - `coding_type` (CodingType): Compression format
 - `detected_format` (ReadFormat): File format (FASTQ or BAM)
 - `output_dir` (Path): Base output directory
@@ -398,7 +398,7 @@ All validators return metadata objects with validation results.
 - `mean_read_length` (float): Average read length (strict mode)
 - `longest_read_length` (int): Longest read length (strict mode)
 - `shortest_read_length` (int): Shortest read length (strict mode)
-- `ngs_type` (str): Configured NGS platform from config (illumina, ont, pacbio)
+- `ngs_type` (str): Configured NGS platform from config (illumina, ont, pacbio-hifi, pacbio-clr)
 - `illumina_pairing_detected` (str): Set to 'illumina' if paired-end pattern detected
 - `base_name` (str): Illumina paired-end base name extracted from filename
 - `read_number` (int): Read number (1 or 2) from pattern detection

--- a/modules/validation/validation-pkg/validation_pkg/docs/SETTINGS.md
+++ b/modules/validation/validation-pkg/validation_pkg/docs/SETTINGS.md
@@ -555,6 +555,7 @@ Automatically create a subdirectory named after the NGS type.
 settings = ReadValidator.Settings(outdir_by_ngs_type=True)
 # Output: {output_dir}/illumina/reads.fastq.gz
 #         {output_dir}/ont/reads.fastq.gz
+#         {output_dir}/pacbio/reads.fastq.gz  # both pacbio-hifi and pacbio-clr
 ```
 
 ---

--- a/modules/validation/validation-pkg/validation_pkg/docs/VALIDATORS.md
+++ b/modules/validation/validation-pkg/validation_pkg/docs/VALIDATORS.md
@@ -221,7 +221,7 @@ ReadValidator(read_config, settings=None)
 - `validation_level`: Validation level
 - `threads`: Number of threads for compression
 - `input_path`: Input file path
-- `ngs_type`: Sequencing platform (illumina, ont, pacbio)
+- `ngs_type`: Sequencing platform (illumina, ont, pacbio-hifi, pacbio-clr)
 - `settings`: Validator settings object
 
 ### Methods
@@ -333,7 +333,7 @@ settings = ReadValidator.Settings(outdir_by_ngs_type=True)
 #   ont/
 #     nanopore_reads.fastq.gz
 #   pacbio/
-#     pacbio_reads.fastq.gz
+#     pacbio_reads.fastq.gz   # both pacbio-hifi and pacbio-clr write here
 ```
 
 ---

--- a/modules/validation/validation-pkg/validation_pkg/utils/formats.py
+++ b/modules/validation/validation-pkg/validation_pkg/utils/formats.py
@@ -302,7 +302,8 @@ class NgsType(Enum):
     """Supported next-generation sequencing technology types."""
     ILLUMINA = "illumina"
     ONT = "ont"
-    PACBIO = "pacbio"
+    PACBIO_HIFI = "pacbio-hifi"
+    PACBIO_CLR = "pacbio-clr"
 
     @classmethod
     def normalize(cls, value):
@@ -315,12 +316,13 @@ class NgsType(Enum):
         mapping = {
             'illumina': cls.ILLUMINA,
             'ont': cls.ONT,
-            'pacbio': cls.PACBIO,
+            'pacbio-hifi': cls.PACBIO_HIFI,
+            'pacbio-clr': cls.PACBIO_CLR,
         }
         if value_lower in mapping:
             return mapping[value_lower]
         raise ValueError(
-            f"'{value}' is not a valid NgsType. Must be one of: illumina, ont, pacbio"
+            f"'{value}' is not a valid NgsType. Must be one of: illumina, ont, pacbio-hifi, pacbio-clr"
         )
 
     @classmethod

--- a/modules/validation/validation-pkg/validation_pkg/validators/read_validator.py
+++ b/modules/validation/validation-pkg/validation_pkg/validators/read_validator.py
@@ -223,9 +223,13 @@ class ReadValidator(BaseValidator):
 
         # Apply outdir_by_ngs_type if enabled
         if self.settings.outdir_by_ngs_type:
-            # Override output_subdir_name with ngs_type
-            self.settings = self.settings.update(output_subdir_name=self.read_config.ngs_type.value)
-            self.logger.debug(f"Applied outdir_by_ngs_type: output_subdir_name set to '{self.read_config.ngs_type.value}'")
+            # Both pacbio subtypes share the same output subdirectory
+            subdir = (
+                "pacbio" if self.read_config.ngs_type.value in ("pacbio-hifi", "pacbio-clr")
+                else self.read_config.ngs_type.value
+            )
+            self.settings = self.settings.update(output_subdir_name=subdir)
+            self.logger.debug(f"Applied outdir_by_ngs_type: output_subdir_name set to '{subdir}'")
 
     # Required abstract properties and methods from BaseValidator
 

--- a/modules/variant_calling.nf
+++ b/modules/variant_calling.nf
@@ -10,13 +10,14 @@ process freebayes {
     each path(fasta_file)
     tuple val(pair_id), path(bam_file), path(bam_index)
     val out_folder_name
+    val ploidy
 
     output:
     tuple val(pair_id), path("${pair_id}.vcf")
 
     script:
     """
-    freebayes -f $fasta_file --min-coverage 10 --min-base-quality 20 --min-mapping-quality 30 --min-alternate-count 3 $bam_file > ${pair_id}.vcf
+    freebayes -f $fasta_file --ploidy $ploidy --min-coverage 10 --min-base-quality 20 --min-mapping-quality 30 --min-alternate-count 3 $bam_file > ${pair_id}.vcf
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -202,11 +202,11 @@ process {
   }
 
   withName: restructure_sv_tbl {
-    container = 'ecomolegmo/validation:v1.0.12@sha256:aae33bd4cb90c7e2d09e7359c7c77a3cb84834c1fa6d9364459d156d2483d8bf'
+    container = 'ecomolegmo/validation:v1.0.13@sha256:0709076d455bd09b3feb043d7a48108191afdcd3b05870d440f06c215d3c0d46'
   }
 
   withName: validate {
-    container = 'ecomolegmo/validation:v1.0.12@sha256:aae33bd4cb90c7e2d09e7359c7c77a3cb84834c1fa6d9364459d156d2483d8bf'
+    container = 'ecomolegmo/validation:v1.0.13@sha256:0709076d455bd09b3feb043d7a48108191afdcd3b05870d440f06c215d3c0d46'
     memory = '8 GB'
     time = '1h'
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -112,7 +112,7 @@ process {
   }
 
   withName: debreak {
-    container = 'ecomolegmo/debreak:v1.0.3@sha256:f2d8f9b5feccb483428558b2afe0cb1ade4689f815902438b3ba84416ed6fdb1'
+    container = 'ecomolegmo/debreak:v1.0.4@sha256:d3d0737fb989840a3d71e39203ddb8c4b43cd22ac8e8a05aff3e88c92e54b603'
     cpus = Math.max(1, Math.min(params.max_cpu as int, 16))
     memory = '96 GB'
     time = '24h'

--- a/nextflow.config
+++ b/nextflow.config
@@ -202,11 +202,11 @@ process {
   }
 
   withName: restructure_sv_tbl {
-    container = 'ecomolegmo/validation:v1.0.11@sha256:5ce2790154e3e85c2e8a1e0df150ba0bcec3b24176a72897a69344d7c0f432a0'
+    container = 'ecomolegmo/validation:v1.0.12@sha256:aae33bd4cb90c7e2d09e7359c7c77a3cb84834c1fa6d9364459d156d2483d8bf'
   }
 
   withName: validate {
-    container = 'ecomolegmo/validation:v1.0.11@sha256:5ce2790154e3e85c2e8a1e0df150ba0bcec3b24176a72897a69344d7c0f432a0'
+    container = 'ecomolegmo/validation:v1.0.12@sha256:aae33bd4cb90c7e2d09e7359c7c77a3cb84834c1fa6d9364459d156d2483d8bf'
     memory = '8 GB'
     time = '1h'
   }

--- a/tools/TOOL_VERSIONS.md
+++ b/tools/TOOL_VERSIONS.md
@@ -1,33 +1,39 @@
-# Tool version pins
+# Custom tool build version pins
 
-This file documents explicit version pins used in custom tool images to improve reproducibility.
+This file documents explicit version pins used while building custom tool images. It is not a license inventory and does not duplicate the container digest table in `docs/project/third-party-licenses.md`.
 
-## Python packages (pinned)
+## Package and binary pins
 
-| Tool image | Package | Version |
+| Build file | Component | Version / ref | Pin source |
 |---|---|---|
-| tools/cutesv/Dockerfile | cuteSV | 2.1.3 |
-| tools/sniffles/Dockerfile | sniffles | 2.7.3 |
-| tools/debreak/Dockerfile | pysam | 0.23.3 |
-| tools/pbzip2/Dockerfile | pbzip2 | 1.1.13 |
-| tools/minimap2/Dockerfile | minimap2 | 2.30 |
-| tools/mosdepth/Dockerfile | mosdepth | 0.3.11 |
-| tools/trimgalore/Dockerfile | trimgalore | 0.6.10 |
-| tools/validation/Dockerfile | validation_pkg | 0.1.0 (local) |
-| tools/validation/Dockerfile | structlog | 25.5.0 |
-| tools/validation/Dockerfile | py3-pandas (Alpine) | 2.3.3-r0 |
+| tools/cutesv/Dockerfile | cuteSV | 2.1.3 | `pip wheel cuteSV==2.1.3` |
+| tools/debreak/Dockerfile | DeBreak | v1.2 | `ARG DEBREAK_REF=v1.2` |
+| tools/debreak/Dockerfile | minimap2 | 2.30 | `ARG MINIMAP2_VERSION=2.30` |
+| tools/debreak/Dockerfile | pysam | 0.23.3 | `ARG PYSAM_VERSION=0.23.3` |
+| tools/gffread/Dockerfile | gffread | v0.12.7 | `ARG GFFREAD_REF=v0.12.7` |
+| tools/minimap2/Dockerfile | minimap2 | 2.30 | `ARG MINIMAP2_VERSION=2.30` |
+| tools/mosdepth/Dockerfile | mosdepth | 0.3.11 | `ARG MOSDEPTH_VERSION=0.3.11` |
+| tools/pbzip2/Dockerfile | pbzip2 | 1.1.13 | source tarball URL |
+| tools/sniffles/Dockerfile | sniffles | 2.7.3 | `ARG SNIFFLES_VERSION=2.7.3` |
+| tools/survivor/Dockerfile | SURVIVOR | 07404b74d3fe42b20f1362f4d8625f284b9d536c | `ARG SURVIVOR_REF=...` |
+| tools/syri/Dockerfile | SyRI | v1.7.1 | `ARG SYRI_REF=v1.7.1` |
+| tools/trimgalore/Dockerfile | cutadapt | 4.9 | `ARG CUTADAPT_VERSION=4.9` |
+| tools/trimgalore/Dockerfile | TrimGalore | 0.6.10 | `ARG TRIMGALORE_VERSION=0.6.10` |
+| tools/validation/Dockerfile | validation package | local source | `COPY modules/validation/ /tmp/validation/` |
+| tools/validation/Dockerfile | structlog | 25.5.0 | scripts venv install |
+| tools/validation/Dockerfile | py3-pandas (Alpine) | 2.3.3-r0 | `apk add py3-pandas=2.3.3-r0` |
 
-## Git sources (pinned)
+## Validation image copied binaries
 
-| File | Repository | Pinned ref | Resolved commit |
+| Consuming build file | Copied image | Digest prefix | Copied binary |
 |---|---|---|---|
-| tools/debreak/Dockerfile | https://github.com/Maggi-Chen/DeBreak.git | v1.2 | 21d9b4294089ccd9df0feec976239551f4359096 |
-| tools/syri/Dockerfile | https://github.com/schneebergerlab/syri.git | v1.7.1 | 61e5aecbb506553c22f88649015013fad28fb05e |
-| tools/survivor/Dockerfile | https://github.com/fritzsedlazeck/SURVIVOR.git | 1.0.7 | 07404b74d3fe42b20f1362f4d8625f284b9d536c |
-| Dockerfile | https://github.com/gpertea/gffread.git | v0.12.7 | 5647f076f616c583ea32fd19629d549d70fc43ea |
+| tools/validation/Dockerfile | ecomolegmo/pbzip2:v1.1.13 | `sha256:4a308661...` | `/usr/bin/pbzip2` |
+| tools/validation/Dockerfile | ecomolegmo/minimap2:v2.30 | `sha256:50d38b71...` | `/usr/local/bin/minimap2` |
+| tools/validation/Dockerfile | ecomolegmo/gffread:v0.12.7 | `sha256:dad98757...` | `/usr/local/bin/gffread` |
 
 ## Notes
 
-- Tag pins are significantly more reproducible than floating branch HEAD installs.
-- For maximum immutability, consider replacing tag pins with commit SHA checkout in Docker builds.
-- For Nextflow container references, prefer image digests (for example image@sha256:...) over mutable tags when publishing production runs.
+- `tools/cutesv/Dockerfile` pins cuteSV itself, but builds `pysam` without an explicit version pin.
+- `tools/syri/Dockerfile` installs SyRI dependencies (`pandas`, `numpy`, `pysam`, `scipy`, `cython`, `igraph`, `matplotlib`, `psutil`) without explicit version pins.
+- Git tag refs are more reproducible than floating branch installs, but commit SHA checkouts are stronger when an upstream tag is not immutable.
+- Runtime Nextflow container image tags and digests are tracked in `nextflow.config` and summarized in `docs/project/third-party-licenses.md`.

--- a/tools/debreak/Dockerfile
+++ b/tools/debreak/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.12-slim@sha256:3d5ed973e45820f5ba5e46bd065bd88b3a504ff0724d85980dc
 
 ARG PYSAM_VERSION=0.23.3
 ARG DEBREAK_REF=v1.2
+ARG MINIMAP2_VERSION=2.30
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -10,6 +11,7 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     git \
     libbz2-dev \
+    zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip
@@ -18,6 +20,8 @@ RUN pip wheel pysam==${PYSAM_VERSION} --no-cache-dir -w /wheels
 
 WORKDIR /build
 RUN git clone --branch ${DEBREAK_REF} --depth 1 https://github.com/Maggi-Chen/DeBreak.git
+RUN git clone --branch v${MINIMAP2_VERSION} --depth 1 https://github.com/lh3/minimap2.git \
+ && make -C minimap2
 
 # Second stage: Final minimal image
 FROM python:3.12-slim@sha256:3d5ed973e45820f5ba5e46bd065bd88b3a504ff0724d85980dcd05eab361fcf4
@@ -31,6 +35,7 @@ COPY --from=builder /wheels /wheels
 RUN pip install --no-cache-dir /wheels/*
 
 COPY --from=builder /build/DeBreak /DeBreak
+COPY --from=builder /build/minimap2/minimap2 /usr/local/bin/minimap2
 
 RUN chmod +x /DeBreak/debreak
 

--- a/workflows/analysis.nf
+++ b/workflows/analysis.nf
@@ -30,6 +30,16 @@ workflow analysis {
         mod_fasta = pmap.map { file(it.mod_fasta_validated) }
         ref_genome_size_bp = pmap.map { it.ref_genome_size_bp ?: "" }
         mod_genome_size_bp = pmap.map { it.mod_genome_size_bp ?: "" }
+        freebayes_ploidy = pmap.map {
+            def organismType = (it.organism_type ?: "").toString().toLowerCase()
+            if (organismType == "prokaryote") {
+                return 1
+            }
+            if (organismType == "eukaryote") {
+                return 2
+            }
+            throw new IllegalArgumentException("Invalid organism_type '${it.organism_type}'. Expected 'prokaryote' or 'eukaryote'.")
+        }
 
         ref_plasmid = pmap.map { it.ref_plasmid_fasta ? [file(it.ref_plasmid_fasta)] : [] }
         mod_plasmid = pmap.map { it.mod_plasmid_fasta ? [file(it.mod_plasmid_fasta)] : [] }
@@ -94,8 +104,8 @@ workflow analysis {
 
         qc(illumina_reads, "illumina/qc_trimming") | set { trimmed }
 
-        short_ref(trimmed, ref_fasta, "illumina/short-ref", ref_plasmid)
-        short_mod(trimmed, mod_fasta, "illumina/short-mod", mod_plasmid)
+        short_ref(trimmed, ref_fasta, "illumina/short-ref", ref_plasmid, freebayes_ploidy)
+        short_mod(trimmed, mod_fasta, "illumina/short-mod", mod_plasmid, freebayes_ploidy)
         compare_unmapped(short_ref.out.unmapped_fastq, short_mod.out.unmapped_fastq, "short")
 
         // Empty short table when not active

--- a/workflows/analysis.nf
+++ b/workflows/analysis.nf
@@ -57,7 +57,7 @@ workflow analysis {
             .flatMap { it.pacbio_fastqs }
             .map(toNamedFastq)
 
-        pacbio_read_type = pmap.map { it.pacbio_read_type ?: it.read_type ?: "" }
+        pacbio_read_type = pmap.map { it.pacbio_read_type ?: "" }
 
         long_ref_pacbio(pacbio_fastqs, ref_fasta, "map-pb", ref_plasmid, "pacbio/long-ref", pacbio_read_type)
         long_mod_pacbio(pacbio_fastqs, mod_fasta, "map-pb", mod_plasmid, "pacbio/long-mod", pacbio_read_type)
@@ -72,7 +72,7 @@ workflow analysis {
             .flatMap { it.ont_fastqs }
             .map(toNamedFastq)
 
-        ont_read_type = pmap.map { it.ont_read_type ?: it.read_type ?: (it.run_nanopore ? "ont" : "") }
+        ont_read_type = pmap.map { it.run_nanopore ? "ont" : "" }
 
         long_ref_ont(ont_fastqs, ref_fasta, "map-ont", ref_plasmid, "ont/long-ref", ont_read_type)
         long_mod_ont(ont_fastqs, mod_fasta, "map-ont", mod_plasmid, "ont/long-mod", ont_read_type)

--- a/workflows/analysis.nf
+++ b/workflows/analysis.nf
@@ -57,8 +57,10 @@ workflow analysis {
             .flatMap { it.pacbio_fastqs }
             .map(toNamedFastq)
 
-        long_ref_pacbio(pacbio_fastqs, ref_fasta, "map-pb", ref_plasmid, "pacbio/long-ref")
-        long_mod_pacbio(pacbio_fastqs, mod_fasta, "map-pb", mod_plasmid, "pacbio/long-mod")
+        pacbio_read_type = pmap.map { it.pacbio_read_type ?: it.read_type ?: "" }
+
+        long_ref_pacbio(pacbio_fastqs, ref_fasta, "map-pb", ref_plasmid, "pacbio/long-ref", pacbio_read_type)
+        long_mod_pacbio(pacbio_fastqs, mod_fasta, "map-pb", mod_plasmid, "pacbio/long-mod", pacbio_read_type)
         compare_unmapped_pacbio(long_ref_pacbio.out.unmapped_fastq, long_mod_pacbio.out.unmapped_fastq, "pacbio")
 
         // Empty pacbio table when not active
@@ -70,8 +72,10 @@ workflow analysis {
             .flatMap { it.ont_fastqs }
             .map(toNamedFastq)
 
-        long_ref_ont(ont_fastqs, ref_fasta, "map-ont", ref_plasmid, "ont/long-ref")
-        long_mod_ont(ont_fastqs, mod_fasta, "map-ont", mod_plasmid, "ont/long-mod")
+        ont_read_type = pmap.map { it.ont_read_type ?: it.read_type ?: (it.run_nanopore ? "ont" : "") }
+
+        long_ref_ont(ont_fastqs, ref_fasta, "map-ont", ref_plasmid, "ont/long-ref", ont_read_type)
+        long_mod_ont(ont_fastqs, mod_fasta, "map-ont", mod_plasmid, "ont/long-mod", ont_read_type)
         compare_unmapped_ont(long_ref_ont.out.unmapped_fastq, long_mod_ont.out.unmapped_fastq, "ont")
 
         // Empty ont table when not active

--- a/workflows/long_read.nf
+++ b/workflows/long_read.nf
@@ -13,6 +13,7 @@
       - mapping_tag: string used as mapping identifier (e.g., "map-ont" or "map-pb")
       - Optional plasmid FASTA (used to remap unmapped reads)
       - out_folder_name: output path prefix / label (controls conditional SV calling)
+      - read_type: validated long-read type used for SV caller parameters
   - Outputs:
       - Channel of structural variant VCFs (per-run) or Channel.empty() when skipped
       - Channel of unmapped FASTQ reads (after reference and optional plasmid mapping)
@@ -33,11 +34,12 @@ workflow long_read {
         mapping_tag
         plasmid_fasta
         out_folder_name
+        read_type
 
     main:
         // mapping to the reference
         samtools_index(fasta) | set { fai }
-        mapping_long(fastqs, fasta, mapping_tag, out_folder_name) | set { indexed_bam }
+        mapping_long(fastqs, fasta, mapping_tag, out_folder_name, read_type) | set { indexed_bam }
 
         get_unmapped_reads(indexed_bam, out_folder_name) | set { unmapped_fastq }
         
@@ -52,7 +54,7 @@ workflow long_read {
             .flatten()
             | set { plasmid_fasta_present }
 
-        mapping_long_plasmid(unmapped_fastq, plasmid_fasta_present, mapping_tag, "${out_folder_name}-plasmid") | set { unmapped_bam }
+        mapping_long_plasmid(unmapped_fastq, plasmid_fasta_present, mapping_tag, "${out_folder_name}-plasmid", read_type) | set { unmapped_bam }
         get_unmapped_reads_plasmid(unmapped_bam, "${out_folder_name}-plasmid") | set { unmapped_fastq_plasmid }
 
         calc_unmapped_plasmid(unmapped_fastq_plasmid) | map { _pair_id, reads -> reads } | set { nreads_plasmid }
@@ -60,7 +62,7 @@ workflow long_read {
 
         // SV calling against the reference
         if (out_folder_name == "ont/long-ref" || out_folder_name == "pacbio/long-ref") { 
-            sv_long(fasta, fai, indexed_bam, mapping_tag, out_folder_name)
+            sv_long(fasta, fai, indexed_bam, mapping_tag, out_folder_name, read_type)
             vcf_to_table_long(mapping_tag, sv_long.out.merged_vcf) | set { sv_tbl_raw }
 
             sv_tbl_keyed = sv_tbl_raw.map { tsv ->

--- a/workflows/short_read.nf
+++ b/workflows/short_read.nf
@@ -20,6 +20,7 @@ workflow short_read {
         fasta
         out_folder_name
         plasmid_fasta
+        freebayes_ploidy
 
     main:
         // mapping to the reference
@@ -48,7 +49,7 @@ workflow short_read {
          if (out_folder_name == "illumina/short-ref") { 
             
             // SNP & variant calling
-            freebayes(fasta, indexed_bam, out_folder_name) | set { vcf }
+            freebayes(fasta, indexed_bam, out_folder_name, freebayes_ploidy) | set { vcf }
             bcftools_stats(vcf, out_folder_name) | set { bcftools_out }
             
             // Annotation module disabled

--- a/workflows/subworkflows.nf
+++ b/workflows/subworkflows.nf
@@ -70,9 +70,10 @@ workflow mapping_long {
         fasta
         mapping_tag
         out_folder_name
+        read_type
 
     main:
-        minimap2(fastqs, fasta, mapping_tag, out_folder_name) | set { sam }
+        minimap2(fastqs, fasta, mapping_tag, out_folder_name, read_type) | set { sam }
         samtools_sort(sam, out_folder_name) | set { sorted_bam }
         samtools_index_bam(sorted_bam, out_folder_name) | set { indexed_bam }
 
@@ -87,10 +88,11 @@ workflow sv_long {
         indexed_bam
         mapping_tag
         out_folder_name
+        read_type
         
 
     main:
-        cute_sv(fasta, fai, indexed_bam, out_folder_name) | set { cute_vcf }
+        cute_sv(fasta, fai, indexed_bam, out_folder_name, read_type) | set { cute_vcf }
         debreak(fasta, indexed_bam, out_folder_name) | set { debreak_vcf }
         sniffles(fasta, indexed_bam, out_folder_name) | set { sniffles_vcf }
         


### PR DESCRIPTION
- This branch adds organism-aware FreeBayes ploidy handling to the Nextflow workflow.
- Derives freebayes_ploidy from organism_type in validated_params.json:prokaryote -> --ploidy 1, eukaryote -> --ploidy 2
- Threads the derived ploidy value through analysis.nf into the short-read workflow and into the freebayes process.
- Updates the FreeBayes command to include --ploidy $ploidy while preserving existing quality/coverage thresholds.
- Adds validation-time guardrails for unexpected organism_type values with a clear error message.
- Updates Nextflow documentation to describe the derived ploidy behavior, including tool-parameters.md, configuration docs, and running-pipeline docs.
- Updates validation-related container pins from ecomolegmo/validation:v1.0.12 to v1.0.13.