### PR TITLE
EFSA-306: freebayes ploidy

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -149,7 +149,7 @@ EUPL-1.2 is a copyleft license. Its Appendix explicitly lists compatible license
 | ecomolegmo/survivor | v1.0.3@sha256:90263d6b... | Internal build (based on SURVIVOR MIT) |
 | ecomolegmo/syri | v1.0.4@sha256:789d5cdf... | Internal build (based on SyRI MIT) |
 | ecomolegmo/trimgalore | v1.0.1@sha256:802cc917... | Internal build (based on TrimGalore GPL-3.0) |
-| ecomolegmo/validation | v1.0.12@sha256:aae33bd4... | Internal validation/runtime support image |
+| ecomolegmo/validation | v1.0.13@sha256:0709076d... | Internal validation/runtime support image |
 
 ---
 

--- a/docs/nextflow/configuration.md
+++ b/docs/nextflow/configuration.md
@@ -24,7 +24,7 @@ As a result, operational runtime messages are primarily captured in `data/output
 | `cleanup` | `true` | Enables end-of-run cleanup hooks (for example, work directory cleanup) |
 | `validation_level` | `null` | Validation depth: `STRICT`, `TRUST`, or `MINIMAL` — `null` means not forwarded; `config.json` governs |
 | `logging_level` | `null` | Log verbosity: `DEBUG`, `INFO`, `WARNING`, or `ERROR` — `null` means not forwarded; `config.json` governs |
-| `organism_type` | `null` | Organism type: `prokaryote` or `eukaryote` — `null` means not forwarded; `config.json` governs. The validated value is written to `validated_params.json` and used to derive FreeBayes ploidy. |
+| `organism_type` | `null` | Organism type: `prokaryote` or `eukaryote` — `null` means not forwarded; `config.json` governs |
 | `force_defragment_ref` | `false` | Force reference defragmentation — unsupported workaround, use with caution |
 | `help` | `false` | Print help message and exit |
 

--- a/docs/nextflow/configuration.md
+++ b/docs/nextflow/configuration.md
@@ -24,7 +24,7 @@ As a result, operational runtime messages are primarily captured in `data/output
 | `cleanup` | `true` | Enables end-of-run cleanup hooks (for example, work directory cleanup) |
 | `validation_level` | `null` | Validation depth: `STRICT`, `TRUST`, or `MINIMAL` — `null` means not forwarded; `config.json` governs |
 | `logging_level` | `null` | Log verbosity: `DEBUG`, `INFO`, `WARNING`, or `ERROR` — `null` means not forwarded; `config.json` governs |
-| `organism_type` | `null` | Organism type: `PROKARYOTE` or `EUKARYOTE` — `null` means not forwarded; `config.json` governs |
+| `organism_type` | `null` | Organism type: `prokaryote` or `eukaryote` — `null` means not forwarded; `config.json` governs. The validated value is written to `validated_params.json` and used to derive FreeBayes ploidy. |
 | `force_defragment_ref` | `false` | Force reference defragmentation — unsupported workaround, use with caution |
 | `help` | `false` | Print help message and exit |
 
@@ -42,6 +42,17 @@ For options shared between Nextflow and `config.json` (`validation_level`, `logg
 When a param is `null` in `nextflow.config`, the flag is not forwarded to the validation script at all, so `config.json` has full control. A `WARNING` is logged whenever a per-file setting overrides a global `config.json` option.
 
 > `threads` follows the same hierarchy but is not exposed as a Nextflow CLI flag — set it only inside `config.json`.
+
+### Derived Analysis Parameters
+
+The workflow derives FreeBayes ploidy from the validated `organism_type` instead of exposing ploidy as a separate user parameter:
+
+| `organism_type` in `validated_params.json` | Derived FreeBayes argument |
+|--------------------------------------------|----------------------------|
+| `prokaryote` | `--ploidy 1` |
+| `eukaryote` | `--ploidy 2` |
+
+See [Tool Parameter Reference](tool-parameters.md#freebayes-variant-calling) for the full FreeBayes command and rationale.
 
 ## Per-Process Configuration
 

--- a/docs/nextflow/running-pipeline.md
+++ b/docs/nextflow/running-pipeline.md
@@ -59,7 +59,7 @@ NXF_QUIET=false nextflow run main.nf --max_cpu $(nproc)
 | `--max_cpu <n>` | Maximum CPUs per process (default: `1`) |
 | `--validation_level <level>` | Validation depth: `STRICT`, `TRUST`, or `MINIMAL` — overridden by `config.json` when set there |
 | `--logging_level <level>` | Log verbosity: `DEBUG`, `INFO`, `WARNING`, or `ERROR` — overridden by `config.json` when set there |
-| `--organism_type <type>` | Organism type: `PROKARYOTE` or `EUKARYOTE` — overridden by `config.json` when set there |
+| `--organism_type <type>` | Organism type: `prokaryote` or `eukaryote` — overridden by `config.json` when set there. The validated value determines FreeBayes ploidy (`1` for prokaryote, `2` for eukaryote). |
 | `--force_defragment_ref` | Force reference defragmentation — unsupported workaround |
 | `--help` | Print help message and exit |
 

--- a/docs/nextflow/tool-parameters.md
+++ b/docs/nextflow/tool-parameters.md
@@ -1,6 +1,6 @@
 # Tool Parameter Reference
 
-This page documents the hardcoded analysis parameters used by the pipeline's bioinformatics tools. The pipeline supports both **prokaryotic** and **eukaryotic** genomes (set via the `type` field in `config.json`). The current parameter values are suitable for both organism types under typical sequencing conditions.
+This page documents the hardcoded and automatically derived analysis parameters used by the pipeline's bioinformatics tools. The pipeline supports both **prokaryotic** and **eukaryotic** genomes. Validation writes the normalized organism type to `validated_params.json` as `organism_type`, and downstream Nextflow processes consume that value.
 
 ---
 
@@ -11,17 +11,25 @@ This page documents the hardcoded analysis parameters used by the pipeline's bio
 **Module:** `modules/variant_calling.nf`
 
 ```bash
-freebayes -f <ref> --min-coverage 10 --min-base-quality 20 --min-mapping-quality 30 --min-alternate-count 3 <bam>
+freebayes -f <ref> --ploidy <1|2> --min-coverage 10 --min-base-quality 20 --min-mapping-quality 30 --min-alternate-count 3 <bam>
 ```
 
 | Parameter | Value | Freebayes Default | Description |
 |-----------|-------|-------------------|-------------|
+| `--ploidy` | Derived from `organism_type`: `1` for `prokaryote`, `2` for `eukaryote` | 2 | Sample ploidy used by FreeBayes. The value is not user-supplied directly; it is derived from the validated organism type and passed through the short-read workflow to FreeBayes. |
 | `--min-coverage` | 10 | 0 | Minimum number of reads covering a locus to call a variant. The default (0) would attempt calls at sites with a single read, producing many false positives. A value of 10 is a standard threshold for reliable variant calling with moderate Illumina coverage. |
 | `--min-base-quality` | 20 | 0 | Minimum per-base Phred quality score. Q20 (99% per-base accuracy) is the widely accepted quality floor for Illumina data. The default (0) would include low-confidence bases, significantly increasing error-driven false calls. |
 | `--min-mapping-quality` | 30 | 1 | Minimum read mapping Phred score. Q30 (99.9% mapping confidence) ensures only confidently placed reads contribute to variant calls. The default (1) would include multi-mapped and ambiguously placed reads, which is problematic in repetitive regions of both prokaryotic and eukaryotic genomes. |
 | `--min-alternate-count` | 3 | 2 | Minimum number of reads supporting the alternate allele. Slightly stricter than the default (2), providing an additional guard against sequencing-error-driven false positives. |
 
-**Rationale:** These are standard community thresholds for calling SNPs and small indels with moderate Illumina coverage (30–100×). Each value departs from the freebayes default to reduce false positives — particularly important in a regulatory/safety context (GMO assessment). The freebayes defaults are intentionally permissive to support diverse use cases (e.g., low-frequency somatic variants); for GMO detection pipelines these permissive defaults would produce excessive noise.
+**Ploidy derivation:** The validated `organism_type` controls the ploidy passed to FreeBayes:
+
+| `organism_type` | FreeBayes `--ploidy` |
+|-----------------|----------------------|
+| `prokaryote` | `1` |
+| `eukaryote` | `2` |
+
+**Rationale:** `--ploidy 1` matches haploid prokaryotic variant calling, while `--ploidy 2` matches diploid eukaryotic calling. The remaining thresholds are standard community thresholds for calling SNPs and small indels with moderate Illumina coverage (30–100×). Each value departs from the freebayes default to reduce false positives — particularly important in a regulatory/safety context (GMO assessment). The freebayes defaults are intentionally permissive to support diverse use cases (e.g., low-frequency somatic variants); for GMO detection pipelines these permissive defaults would produce excessive noise.
 
 **Trade-offs:**
 
@@ -139,7 +147,7 @@ delta-filter -m -i 90 -l 100 <delta>
 
 | Tool | Pipeline | Module | Key Non-Default Parameters |
 |------|----------|--------|---------------------------|
-| Freebayes | Short-read | `variant_calling.nf` | `--min-coverage 10`, `--min-base-quality 20`, `--min-mapping-quality 30`, `--min-alternate-count 3` |
+| Freebayes | Short-read | `variant_calling.nf` | `--ploidy 1` for `prokaryote` or `--ploidy 2` for `eukaryote`, `--min-coverage 10`, `--min-base-quality 20`, `--min-mapping-quality 30`, `--min-alternate-count 3` |
 | Delly | Short-read | `sv_calling.nf` | Defaults only |
 | cuteSV | Long-read | `sv_calling.nf` | `-t ${task.cpus}` |
 | Sniffles | Long-read | `sv_calling.nf` | Defaults only |

--- a/docs/nextflow/tool-parameters.md
+++ b/docs/nextflow/tool-parameters.md
@@ -1,6 +1,6 @@
 # Tool Parameter Reference
 
-This page documents the hardcoded and automatically derived analysis parameters used by the pipeline's bioinformatics tools. The pipeline supports both **prokaryotic** and **eukaryotic** genomes. Validation writes the normalized organism type to `validated_params.json` as `organism_type`, and downstream Nextflow processes consume that value.
+This page documents the hardcoded and automatically derived analysis parameters used by the pipeline's bioinformatics tools. The pipeline supports both **prokaryotic** and **eukaryotic** genomes. 
 
 ---
 

--- a/docs/nextflow/validation-nextflow-integration.md
+++ b/docs/nextflow/validation-nextflow-integration.md
@@ -15,7 +15,7 @@ At the moment, integration is done through a **JSON handoff**:
 ## Where It Happens
 
 - Validation process definition: `modules/validate.nf`
-- Validation entrypoint script: `validation.sh` is within the pinned `ecomolegmo/validation` image defined in `nextflow.config` (`v1.0.12` at the time of writing)
+- Validation entrypoint script: `validation.sh` is within the pinned `ecomolegmo/validation` image defined in `nextflow.config` (`v1.0.13`)
 - JSON handoff artifact: `validated_params.json`
 - Consumer side (Nextflow): analysis workflow that parses the JSON and maps values into pipeline logic
 

--- a/docs/project/third-party-licenses.md
+++ b/docs/project/third-party-licenses.md
@@ -150,7 +150,7 @@ EUPL-1.2 is a copyleft license. Its Appendix explicitly lists compatible license
 | ecomolegmo/survivor | v1.0.3@sha256:90263d6b... | Internal build (based on SURVIVOR MIT) |
 | ecomolegmo/syri | v1.0.4@sha256:789d5cdf... | Internal build (based on SyRI MIT) |
 | ecomolegmo/trimgalore | v1.0.1@sha256:802cc917... | Internal build (based on TrimGalore GPL-3.0) |
-| ecomolegmo/validation | v1.0.12@sha256:aae33bd4... | Internal validation/runtime support image |
+| ecomolegmo/validation | v1.0.13@sha256:0709076d... | Internal validation/runtime support image |
 
 ---
 

--- a/docs/validation/OVERVIEW.md
+++ b/docs/validation/OVERVIEW.md
@@ -95,6 +95,7 @@ It is used at runtime by the analysis workflow to determine which pipelines to e
 | `run_nanopore`          | boolean | `true` when validated Nanopore (ONT) reads are present (FASTQ or BAM).                               |
 | `run_pacbio`            | boolean | `true` when validated PacBio reads are present (FASTQ or BAM).                                       |
 | `pacbio_read_type`      | string  | `"pacbio-hifi"` or `"pacbio-clr"` when `run_pacbio` is `true`; `null` otherwise.                    |
+| `organism_type`         | string  | `"prokaryote"` or `"eukaryote"`, taken from the `type` field in `config.json` options.               |
 | `contig_file_size`      | integer | Number of contig files produced by inter-genome characterisation.                                     |
 | `ref_genome_size_bp`    | integer | Validated reference genome size in base pairs, used by `restructure_sv_tbl` to calculate `pct_of_ref_genome`. Omitted when unavailable. |
 | `mod_genome_size_bp`    | integer | Validated modified genome size in base pairs, used by `restructure_sv_tbl` to calculate `pct_of_mod_genome`. Omitted when unavailable. |

--- a/modules/variant_calling.nf
+++ b/modules/variant_calling.nf
@@ -10,13 +10,14 @@ process freebayes {
     each path(fasta_file)
     tuple val(pair_id), path(bam_file), path(bam_index)
     val out_folder_name
+    val ploidy
 
     output:
     tuple val(pair_id), path("${pair_id}.vcf")
 
     script:
     """
-    freebayes -f $fasta_file --min-coverage 10 --min-base-quality 20 --min-mapping-quality 30 --min-alternate-count 3 $bam_file > ${pair_id}.vcf
+    freebayes -f $fasta_file --ploidy $ploidy --min-coverage 10 --min-base-quality 20 --min-mapping-quality 30 --min-alternate-count 3 $bam_file > ${pair_id}.vcf
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -202,11 +202,11 @@ process {
   }
 
   withName: restructure_sv_tbl {
-    container = 'ecomolegmo/validation:v1.0.12@sha256:aae33bd4cb90c7e2d09e7359c7c77a3cb84834c1fa6d9364459d156d2483d8bf'
+    container = 'ecomolegmo/validation:v1.0.13@sha256:0709076d455bd09b3feb043d7a48108191afdcd3b05870d440f06c215d3c0d46'
   }
 
   withName: validate {
-    container = 'ecomolegmo/validation:v1.0.12@sha256:aae33bd4cb90c7e2d09e7359c7c77a3cb84834c1fa6d9364459d156d2483d8bf'
+    container = 'ecomolegmo/validation:v1.0.13@sha256:0709076d455bd09b3feb043d7a48108191afdcd3b05870d440f06c215d3c0d46'
     memory = '8 GB'
     time = '1h'
   }

--- a/workflows/analysis.nf
+++ b/workflows/analysis.nf
@@ -30,6 +30,16 @@ workflow analysis {
         mod_fasta = pmap.map { file(it.mod_fasta_validated) }
         ref_genome_size_bp = pmap.map { it.ref_genome_size_bp ?: "" }
         mod_genome_size_bp = pmap.map { it.mod_genome_size_bp ?: "" }
+        freebayes_ploidy = pmap.map {
+            def organismType = (it.organism_type ?: "").toString().toLowerCase()
+            if (organismType == "prokaryote") {
+                return 1
+            }
+            if (organismType == "eukaryote") {
+                return 2
+            }
+            throw new IllegalArgumentException("Invalid organism_type '${it.organism_type}'. Expected 'prokaryote' or 'eukaryote'.")
+        }
 
         ref_plasmid = pmap.map { it.ref_plasmid_fasta ? [file(it.ref_plasmid_fasta)] : [] }
         mod_plasmid = pmap.map { it.mod_plasmid_fasta ? [file(it.mod_plasmid_fasta)] : [] }
@@ -94,8 +104,8 @@ workflow analysis {
 
         qc(illumina_reads, "illumina/qc_trimming") | set { trimmed }
 
-        short_ref(trimmed, ref_fasta, "illumina/short-ref", ref_plasmid)
-        short_mod(trimmed, mod_fasta, "illumina/short-mod", mod_plasmid)
+        short_ref(trimmed, ref_fasta, "illumina/short-ref", ref_plasmid, freebayes_ploidy)
+        short_mod(trimmed, mod_fasta, "illumina/short-mod", mod_plasmid, freebayes_ploidy)
         compare_unmapped(short_ref.out.unmapped_fastq, short_mod.out.unmapped_fastq, "short")
 
         // Empty short table when not active

--- a/workflows/short_read.nf
+++ b/workflows/short_read.nf
@@ -20,6 +20,7 @@ workflow short_read {
         fasta
         out_folder_name
         plasmid_fasta
+        freebayes_ploidy
 
     main:
         // mapping to the reference
@@ -48,7 +49,7 @@ workflow short_read {
          if (out_folder_name == "illumina/short-ref") { 
             
             // SNP & variant calling
-            freebayes(fasta, indexed_bam, out_folder_name) | set { vcf }
+            freebayes(fasta, indexed_bam, out_folder_name, freebayes_ploidy) | set { vcf }
             bcftools_stats(vcf, out_folder_name) | set { bcftools_out }
             
             // Annotation module disabled


### PR DESCRIPTION
-     This branch adds organism-aware FreeBayes ploidy handling to the Nextflow workflow.
-     Derives freebayes_ploidy from organism_type in validated_params.json:prokaryote -> --ploidy 1, eukaryote -> --ploidy 2
-     Threads the derived ploidy value through analysis.nf into the short-read workflow and into the freebayes process.
-     Updates the FreeBayes command to include --ploidy $ploidy while preserving existing quality/coverage thresholds.
-     Adds validation-time guardrails for unexpected organism_type values with a clear error message.
-     Updates Nextflow documentation to describe the derived ploidy behavior, including tool-parameters.md, configuration docs, and running-pipeline docs.
-     Updates validation-related container pins from ecomolegmo/validation:v1.0.12 to v1.0.13.