### PR TITLE
EFSA-309: syri can crash

### DIFF
--- a/docs/nextflow/configuration.md
+++ b/docs/nextflow/configuration.md
@@ -21,7 +21,7 @@ As a result, operational runtime messages are primarily captured in `data/output
 | `log_dir` | `data/outputs/logs` | Directory for pipeline logs and reports |
 | `valid_dir` | `data/outputs/valid` | Directory where only `validated_params.json` is saved |
 | `max_cpu` | `1` | Maximum CPUs available per process (override with `--max_cpu`) |
-| `cleanup` | `true` | Enables end-of-run cleanup hooks (for example, work directory cleanup) |
+| `clean_workdir` | `false` | Controls whether the Nextflow work directory is deleted at the end of a run; set to `true` to delete it |
 | `validation_level` | `null` | Validation depth: `STRICT`, `TRUST`, or `MINIMAL` — `null` means not forwarded; `config.json` governs |
 | `logging_level` | `null` | Log verbosity: `DEBUG`, `INFO`, `WARNING`, or `ERROR` — `null` means not forwarded; `config.json` governs |
 | `organism_type` | `null` | Organism type: `prokaryote` or `eukaryote` — `null` means not forwarded; `config.json` governs |

--- a/docs/outputs/logs.md
+++ b/docs/outputs/logs.md
@@ -99,7 +99,7 @@ The pipeline uses `errorStrategy = 'terminate'` globally — see [Configuration]
 
 ## Log Copying Behavior
 
-Process logs (`.command.*` files) are copied from the Nextflow `work/` directory to `data/outputs/logs/` **regardless of whether the pipeline succeeds or fails**. This ensures failure diagnostics are always available even after the work directory is cleaned up.
+Process logs (`.command.*` files) are copied from the Nextflow `work/` directory to `data/outputs/logs/` **regardless of whether the pipeline succeeds or fails**. This ensures failure diagnostics are always available when `clean_workdir` is enabled and the work directory is deleted.
 
 ## Usage
 
@@ -112,7 +112,7 @@ These log files are useful for:
 
 ## Accessing Logs
 
-During execution, logs reside in the Nextflow `work/` directory under each process-specific subdirectory. At pipeline completion (success or failure), all `.command.*` files are automatically copied to `data/outputs/logs/`. The pipeline then attempts to remove the `work/` directory, while preserving copied logs in the output directory.
+During execution, logs reside in the Nextflow `work/` directory under each process-specific subdirectory. At pipeline completion (success or failure), all `.command.*` files are automatically copied to `data/outputs/logs/`. If `clean_workdir` is `true`, the pipeline then attempts to remove the `work/` directory while preserving copied logs in the output directory. If `clean_workdir` is `false`, the `work/` directory is kept.
 
 To quickly check which processes failed, inspect `data/outputs/logs/process_manifest.txt`.
 

--- a/main.nf
+++ b/main.nf
@@ -45,6 +45,8 @@ workflow {
     validate(config_ch)
     analysis(validate.out.params_json)
 
+    def cleanWorkdir = params.clean_workdir
+
     workflow.onComplete { wf ->
         def workDir = resolveWorkDir(wf)
         def logDir = getLogDir()
@@ -53,7 +55,12 @@ workflow {
         generateProcessManifest(logDir, wf)
         logCompletionSummary(wf, workDir)
 
-        if (workDir.deleteDir()) {
+        def keepWorkdir = cleanWorkdir == false || cleanWorkdir?.toString()?.toLowerCase() == 'false'
+
+        if (keepWorkdir) {
+            logToNextflowFile("Keeping work directory: ${workDir.absolutePath}\n")
+        }
+        else if (workDir.deleteDir()) {
             logToNextflowFile("🧹 Removed work directory: ${workDir.absolutePath}\n")
         }
         else {

--- a/modules/assembly.nf
+++ b/modules/assembly.nf
@@ -68,6 +68,20 @@ process syri {
 
     script:
     """
+    set -euo pipefail
+
+    if [ ! -s "$coords" ] || [ ! -s "$filtered_delta" ]; then
+        printf '%s\\n' \\
+            '##fileformat=VCFv4.2' \\
+            '##source=syri_empty_coords_guard' \\
+            '##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant">' \\
+            '##INFO=<ID=StartB,Number=1,Type=Integer,Description="Start position in query genome">' \\
+            '##INFO=<ID=EndB,Number=1,Type=Integer,Description="End position in query genome">' \\
+            '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO' \\
+            > ${prefix}syri.vcf
+        exit 0
+    fi
+        
     syri -c $coords -d $filtered_delta  -r $ref -q $mod --prefix ${prefix} --nosnp
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,7 +7,7 @@ params {
 
   help = false
   max_cpu = 1
-  cleanup = true
+  clean_workdir = false
 
   ref_plasmid_fasta = null
   mod_plasmid_fasta = null


### PR DESCRIPTION
**PR Summary**
- Added a guard in `modules/assembly.nf` so syri emits an empty valid VCF and exits successfully when coords or filtered_delta is empty.
- Replaced the old cleanup parameter with `clean_workdir`.
- Updated workflow.onComplete so:`clean_workdir = false` keeps the Nextflow `work/` directory.
- clean_workdir = true deletes the `work/` directory.

- Captured `params.clean_workdir` before workflow.onComplete to avoid params being null inside the completion handler.
- Updated documentation in:
  - docs/nextflow/configuration.md
  - docs/outputs/logs.md