### PR TITLE
EFSA-307: add filtering of wrong artifacts

### DIFF
--- a/docs/outputs/sv-tables.md
+++ b/docs/outputs/sv-tables.md
@@ -30,6 +30,7 @@ flowchart LR
 - Final event rows are first built by clustering records within the same chromosome and standardized SV type, then a final pass adds `linked_event` entries for overlapping final SV rows on the same chromosome.
 - `linked_event` is the only relationship column in the final CSVs. It includes both same-type and cross-type overlaps.
 - Final event anchoring is deterministic and size-aware: `event_length_bp` uses minimum absolute `svlen`, and event coordinates are anchored to the same selected source call. Equal-length ties are resolved by strongest intersection with the other source calls.
+- Likely artifact rows can be filtered before clustering when the source TSV provides contig length: by default, events larger than 50% of their contig are removed.
 
 ### VCF Extraction and Variant Type Handling
 
@@ -147,6 +148,24 @@ During normal Nextflow runs, genome-size context is supplied automatically from 
 | `--out` | Output directory for the per-SV CSV files. Required. |
 | `--tol` | Within-type clustering tolerance in base pairs. Determines whether raw SV calls get merged into the same event. Default: `10`. |
 | `--cross_type_tol` | Tolerance in base pairs for linking final events with near-identical coordinates in `linked_event`. Default: `0`, which keeps overlap-only linking. |
+| `--max_event_contig_fraction` | Filters source rows whose event length is greater than this fraction of the row's contig length. Default: `0.5` (50%). Set to `0` to disable. Rows without a supported contig-length column are retained. |
+
+### Artifact filtering and known limitations
+
+As per EFSA request, a few events for filtering out has been created. Those filters are used to remove incorrect events (artifacts) or consolidate overlapping events into single, unique event. Currently handled artifact categories:
+
+- **Too-large source events:** before clustering, a source row is removed when `abs(svlen) > contig_length * --max_event_contig_fraction`. The default threshold is `0.5`. Supported optional contig-length column names include `contig_length_bp`, `contig_length`, `contig_size_bp`, `contig_size`, `chrom_length_bp`, `chrom_length`, `chrom_size_bp`, `chrom_size`, `chromosome_length_bp`, `chromosome_length`, `chromosome_size_bp`, `chromosome_size`, `sequence_length_bp`, `sequence_length`, `ref_contig_length_bp`, `ref_contig_length`, `ref_chrom_length_bp`, and `ref_chrom_length`.
+- **Rows without contig length:** retained deliberately and counted in the structured log as unevaluated by the too-large-event filter. The script does not guess contig size from total genome size or observed coordinates.
+- **Malformed source rows:** rows missing required fields or valid coordinates are skipped during loading.
+- **Normalization artifacts:** reversed coordinates are swapped; signed or inconsistent `svlen` values are normalized for interval SV classes (`DEL`, `DUP`, `INV`, `RPL`) before filtering and output.
+- **Nested/overlapping final events:** not filtered automatically, but reported through `linked_event` relations such as `nested_in`, `contains`, `overlap`, and `exact_coordinates`.
+
+Known unresolved or only partially resolved artifact categories:
+
+- **Deletion plus substitution double-calls from non-clean deletion boundaries:** not collapsed automatically because the final table builder does not read BAM/IGV evidence or base-level alignment context.
+- **Substitution events duplicated as deletion/insertion calls:** not safely filtered from the current columns alone; these are exposed only through coordinate/type relationships when they overlap.
+- **Deletion-inside-deletion artifacts:** not removed automatically. Nested relationships are annotated in `linked_event` for review, but the script avoids deleting nested calls without stronger evidence.
+- **Coverage/visual-review artifacts:** no BAM- or IGV-derived artifact logic is applied in `create_sv_output.py`; only fields already present in the TSV inputs are used.
 
 ### Explanation of `csv_per_sv_summary` CSV columns
 
@@ -274,28 +293,30 @@ The `create_sv_output.py` script processes SV records through the following step
 
 1. **Load and standardize records** from all available source pipelines (assembly, long-read ONT/PacBio, short-read)
 
-2. **Cluster records by (chromosome, standardized SV type)** using interval overlap with a tolerance window (`--tol`, default 10 bp). Records are considered part of the same event if:
+2. **Filter supported too-large source events** before clustering. A row is removed only when both event length and contig length are available and `abs(svlen)` exceeds `contig_length * --max_event_contig_fraction`.
+
+3. **Cluster records by (chromosome, standardized SV type)** using interval overlap with a tolerance window (`--tol`, default 10 bp). Records are considered part of the same event if:
    - They share the same chromosome and standardized SV type
    - Their intervals overlap (accounting for tolerance)
    - At least one of the breakpoints (start or end) is within tolerance between members
 
-3. **Select best representative per source** within each cluster using a ranking strategy:
+4. **Select best representative per source** within each cluster using a ranking strategy:
    - Rank 1: Supporting reads / evidence count (higher is better)
    - Rank 2: Quality score (higher is better)
    - Rank 3: Absolute SV size (`abs(svlen)`), with smaller values preferred as tie-breaker
    
    This ensures the highest-confidence call from each source is carried forward.
 
-4. **Build source length candidates** from selected source representatives:
+5. **Build source length candidates** from selected source representatives:
    - `asm_length`, `long_ont_length`, `long_pacbio_length`, `short_length` from source `svlen`
    - Event-level comparison uses absolute lengths (`abs(svlen)`) to normalize caller sign conventions
 
-5. **Select event anchor and event length:**
+6. **Select event anchor and event length:**
    - Set `event_length_bp = min(abs(svlen))` across available source representatives
    - Set `event_start` and `event_end` to the coordinates of the same selected source call
    - If multiple sources share the same minimum absolute length, choose the one with the largest total interval intersection against other source representatives
    - If no usable source `svlen` exists, keep `event_length_bp = NaN` and use type-aware fallback coordinates
 
-6. **Assemble final row** with all source-specific fields, filtering unnecessary columns (e.g., removing `asm_start_mod/asm_end_mod` from deletions, removing internal type fields)
+7. **Assemble final row** with all source-specific fields, filtering unnecessary columns (e.g., removing `asm_start_mod/asm_end_mod` from deletions, removing internal type fields)
 
-7. **Final pass: link overlapping events** by scanning all final rows on the same chromosome and recording any coordinate overlaps or near-overlaps (if `--cross_type_tol` is set)
+8. **Final pass: link overlapping events** by scanning all final rows on the same chromosome and recording any coordinate overlaps or near-overlaps (if `--cross_type_tol` is set)

--- a/modules/utils/create_sv_output.py
+++ b/modules/utils/create_sv_output.py
@@ -44,7 +44,14 @@ events for both same-type and cross-type SV rows. Set --cross_type_tol to a smal
 integer to also link near-identical final coordinates.
 
 Usage:
-    python create_sv_output.py --asm assembly.tsv --long_ont long_ont.tsv --long_pacbio long_pb.tsv --short short.tsv --out outdir --tol 10 --cross_type_tol 0
+    python create_sv_output.py --asm assembly.tsv --long_ont long_ont.tsv --long_pacbio long_pb.tsv --short short.tsv --out outdir --tol 10 --cross_type_tol 0 --max_event_contig_fraction 0.5
+
+Too-large event artifact filter:
+    Source rows are filtered before clustering when both event length and contig
+    length are available and abs(svlen) is greater than the configured fraction
+    of the contig length. The default maximum fraction is 0.5 (50%). Rows with
+    unavailable event length or contig length are retained and logged as not
+    evaluated by this filter.
 
 Genome-percentage columns:
     pct_of_ref_genome and pct_of_mod_genome are calculated when the pipeline sets
@@ -63,6 +70,7 @@ import atexit
 import argparse
 import logging
 import glob
+import math
 import os
 import re
 from io import StringIO
@@ -120,6 +128,29 @@ ASM_PREFIX_MAP = [
 ]
 
 DEFAULT_LOG_DIR = Path("data") / "outputs" / "logs"
+DEFAULT_MAX_EVENT_CONTIG_FRACTION = 0.5
+
+CONTIG_LENGTH_COLUMNS = (
+    "contig_length_bp",
+    "contig_length",
+    "contig_size_bp",
+    "contig_size",
+    "chrom_length_bp",
+    "chrom_length",
+    "chrom_size_bp",
+    "chrom_size",
+    "chromosome_length_bp",
+    "chromosome_length",
+    "chromosome_size_bp",
+    "chromosome_size",
+    "sequence_length_bp",
+    "sequence_length",
+    "ref_contig_length_bp",
+    "ref_contig_length",
+    "ref_chrom_length_bp",
+    "ref_chrom_length",
+)
+
 ROW_LOG_FIELDS = (
     "chrom",
     "#chrom",
@@ -139,6 +170,7 @@ ROW_LOG_FIELDS = (
     "coverage_before_100bp",
     "coverage_sv_span",
     "coverage_after_100bp",
+    *CONTIG_LENGTH_COLUMNS,
     # Delly raw fields (short-read)
     "PE",   # INFO paired-end support of the structural variant
     "SR",   # INFO split-read support
@@ -362,6 +394,27 @@ def _first_int(row: Dict[str, Any], names: List[str]) -> Optional[int]:
     return None
 
 
+def _resolve_contig_length_bp(row: Dict[str, Any]) -> Optional[int]:
+    """Return a positive contig length from supported optional TSV columns."""
+    contig_length = _first_int(row, list(CONTIG_LENGTH_COLUMNS))
+    if contig_length is None or contig_length <= 0:
+        return None
+    return contig_length
+
+
+def _parse_nonnegative_finite_float(value: str) -> float:
+    """argparse type for non-negative finite floating-point options."""
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid number") from exc
+
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError("value must be a non-negative finite number")
+
+    return parsed
+
+
 def _resolve_delly_supporting_reads_details(row: Dict[str, Any]) -> Dict[str, Any]:
     """Compute Delly short-read support and preserve its provenance.
 
@@ -514,6 +567,7 @@ class Record:
     supporting_reads_format: Optional[int] = None
     supporting_reads_generic: Optional[int] = None
     supporting_reads_note: Optional[str] = None
+    contig_length_bp: Optional[int] = None
 
 @dataclass
 class EventCluster:
@@ -606,6 +660,118 @@ def choose_best_record(recs: List[Record]) -> Optional[Record]:
         )
 
     return max(recs, key=key)
+
+
+def _record_event_length_bp(record: Record) -> Optional[int]:
+    """Return the absolute source-event length used by artifact filters."""
+    if record.svlen is None:
+        return None
+    try:
+        if pd.isna(record.svlen):
+            return None
+    except Exception:
+        pass
+
+    try:
+        return abs(int(record.svlen))
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_too_large_event_artifact(
+    record: Record,
+    max_contig_fraction: float,
+) -> Tuple[bool, Optional[int], Optional[float]]:
+    """Identify source rows whose event length is implausibly large for the contig.
+
+    Rows without event length or contig length are deliberately not filtered here;
+    callers can report that they were unevaluated.
+    """
+    event_length_bp = _record_event_length_bp(record)
+    contig_length_bp = record.contig_length_bp
+
+    if max_contig_fraction <= 0:
+        return False, event_length_bp, None
+
+    if event_length_bp is None or contig_length_bp is None or contig_length_bp <= 0:
+        return False, event_length_bp, None
+
+    event_contig_fraction = event_length_bp / contig_length_bp
+    return event_contig_fraction > max_contig_fraction, event_length_bp, event_contig_fraction
+
+
+def filter_too_large_events(
+    records: List[Record],
+    max_contig_fraction: float = DEFAULT_MAX_EVENT_CONTIG_FRACTION,
+    logger: Any = None,
+) -> List[Record]:
+    """Remove likely artifact source rows that exceed a fraction of contig length."""
+    if not records:
+        return records
+
+    if max_contig_fraction <= 0:
+        if logger is not None:
+            logger.info(
+                "too_large_event_filter_disabled",
+                max_event_contig_fraction=max_contig_fraction,
+                total_records=len(records),
+            )
+        return records
+
+    kept: List[Record] = []
+    filtered_count = 0
+    missing_event_length_count = 0
+    missing_contig_length_count = 0
+
+    for record in records:
+        event_length_bp = _record_event_length_bp(record)
+        if event_length_bp is None:
+            missing_event_length_count += 1
+            kept.append(record)
+            continue
+
+        if record.contig_length_bp is None or record.contig_length_bp <= 0:
+            missing_contig_length_count += 1
+            kept.append(record)
+            continue
+
+        is_artifact, _, event_contig_fraction = _is_too_large_event_artifact(
+            record,
+            max_contig_fraction,
+        )
+        if is_artifact:
+            filtered_count += 1
+            if logger is not None:
+                logger.warning(
+                    "sv_artifact_row_filtered",
+                    reason="event_length_gt_contig_fraction",
+                    source=record.source,
+                    chrom=record.chrom,
+                    start=record.start,
+                    end=record.end,
+                    std_type=record.std_type,
+                    raw_svtype=record.raw_svtype,
+                    event_length_bp=event_length_bp,
+                    contig_length_bp=record.contig_length_bp,
+                    event_contig_fraction=event_contig_fraction,
+                    max_event_contig_fraction=max_contig_fraction,
+                )
+            continue
+
+        kept.append(record)
+
+    if logger is not None:
+        logger.info(
+            "too_large_event_filter_completed",
+            max_event_contig_fraction=max_contig_fraction,
+            total_records=len(records),
+            kept_records=len(kept),
+            filtered_records=filtered_count,
+            unevaluated_missing_event_length=missing_event_length_count,
+            unevaluated_missing_contig_length=missing_contig_length_count,
+        )
+
+    return kept
 
 def read_tsv(path: Union[str, Path]) -> pd.DataFrame:
     """Read a TSV summary while preserving a leading ``#chrom`` header.
@@ -862,6 +1028,7 @@ def load_records(path: Optional[Union[str, Path]], source: str, logger: Any = No
         coverage_before_100bp = _to_float(row.get("coverage_before_100bp"))
         coverage_sv_span = _to_float(row.get("coverage_sv_span"))
         coverage_after_100bp = _to_float(row.get("coverage_after_100bp"))
+        contig_length_bp = _resolve_contig_length_bp(row)
         svlen_input = _to_int(row.get("svlen"))
         svlen = abs(svlen_input) if svlen_input is not None else None
         coord_len = (end - start) if (start is not None and end is not None and end >= start) else None
@@ -1004,6 +1171,7 @@ def load_records(path: Optional[Union[str, Path]], source: str, logger: Any = No
                 supporting_reads_format,
                 supporting_reads_generic,
                 supporting_reads_note,
+                contig_length_bp=contig_length_bp,
             )
         )
 
@@ -1413,6 +1581,16 @@ def main() -> None:
         default=0,
         help="Tolerance in bp for linking near-identical final event coordinates in linked_event. Default 0 keeps overlap-only linking.",
     )
+    p.add_argument(
+        "--max_event_contig_fraction",
+        type=_parse_nonnegative_finite_float,
+        default=DEFAULT_MAX_EVENT_CONTIG_FRACTION,
+        help=(
+            "Filter source SV rows whose event length is greater than this "
+            "fraction of the available contig length. Default 0.5. Set 0 to disable. "
+            "Rows without contig length are retained."
+        ),
+    )
 
     args = p.parse_args()
 
@@ -1436,6 +1614,7 @@ def main() -> None:
         output_dir=str(args.out),
         tol=args.tol,
         cross_type_tol=args.cross_type_tol,
+        max_event_contig_fraction=args.max_event_contig_fraction,
         ref_genome_size_bp=ref_genome_size_bp,
         mod_genome_size_bp=mod_genome_size_bp,
         inputs=_clean_dict(
@@ -1470,14 +1649,22 @@ def main() -> None:
         records = resolve_supporting_reads(records, supp_files, tol=args.tol)
         logger.info("resolve_supporting_reads_completed", total_records=len(records))
 
+    records_before_artifact_filter = len(records)
+    records = filter_too_large_events(
+        records,
+        max_contig_fraction=args.max_event_contig_fraction,
+        logger=logger,
+    )
+
     if not records:
         os.makedirs(args.out, exist_ok=True)
         logger.warning(
             "create_sv_output_no_valid_records",
             output_dir=str(args.out),
+            records_before_artifact_filter=records_before_artifact_filter,
         )
         write_csv_tables(pd.DataFrame(), args.out)
-        print("No valid input records found; wrote empty header-only CSV tables.")
+        print("No valid input records found after input validation/artifact filtering; wrote empty header-only CSV tables.")
         print(f"Load-record audit log: {log_path}")
         return
 
@@ -1511,6 +1698,7 @@ def main() -> None:
         total_records=len(records),
         total_clusters=len(clusters),
         total_output_rows=int(len(df.index)),
+        records_before_artifact_filter=records_before_artifact_filter,
     )
 
     print(f"Wrote CSV tables to: {args.out}")


### PR DESCRIPTION
- Added `--max_event_contig_fraction` with default `0.5`; `0` disables the filter.
- Filters source SV rows before clustering when `abs(svlen) > contig_length * threshold`.
- Rows missing event length or supported contig-length columns are retained and logged as unevaluated.
- Docs now list handled artifact categories and unresolved duplicate/nested-call limitations.