### PR TITLE
EFSA-310: merge overlapping deletions

### DIFF
--- a/docs/outputs/sv-tables.md
+++ b/docs/outputs/sv-tables.md
@@ -28,6 +28,7 @@ flowchart LR
 - `restructure_sv_tbl` process: the merge step accepts any subset of (assembly, long_ont, long_pacbio, short) and ignores missing files.
 - Long reads are handled as two separate sources: `long_ont` and `long_pacbio`. Output CSVs keep these in distinct `long_ont_*` and `long_pacbio_*` columns.
 - Final event rows are first built by clustering records within the same chromosome and standardized SV type, then a final pass adds `linked_event` entries for overlapping final SV rows on the same chromosome.
+- Deletion clustering is interval-based: same-chromosome `DEL` calls merge when their intervals overlap or touch within `--tol`, even when neither breakpoint is nearby. Other SV types keep the more conservative breakpoint-proximity rule.
 - `linked_event` is the only relationship column in the final CSVs. It includes both same-type and cross-type overlaps.
 - Final event anchoring is deterministic and size-aware: `event_length_bp` uses minimum absolute `svlen`, and event coordinates are anchored to the same selected source call. Equal-length ties are resolved by strongest intersection with the other source calls.
 - Likely artifact rows can be filtered before clustering when the source TSV provides contig length: by default, events larger than 50% of their contig are removed.
@@ -146,25 +147,35 @@ During normal Nextflow runs, genome-size context is supplied automatically from 
 | `--long_pacbio` | TSV file containing structural variant summary from PacBio long-read data. Optional. |
 | `--short` | TSV file containing structural variant summary from short-read sequencing data. Optional. |
 | `--out` | Output directory for the per-SV CSV files. Required. |
-| `--tol` | Within-type clustering tolerance in base pairs. Determines whether raw SV calls get merged into the same event. Default: `10`. |
+| `--tol` | Within-type clustering tolerance in base pairs. For `DEL`, intervals that overlap or touch within this distance are merged. For other SV types, intervals must overlap/touch and have a nearby start or end breakpoint. Default: `10`. |
 | `--cross_type_tol` | Tolerance in base pairs for linking final events with near-identical coordinates in `linked_event`. Default: `0`, which keeps overlap-only linking. |
 | `--max_event_contig_fraction` | Filters source rows whose event length is greater than this fraction of the row's contig length. Default: `0.5` (50%). Set to `0` to disable. Rows without a supported contig-length column are retained. |
 
 ### Artifact filtering and known limitations
 
-As per EFSA request, a few events for filtering out has been created. Those filters are used to remove incorrect events (artifacts) or consolidate overlapping events into single, unique event. Currently handled artifact categories:
+As per EFSA request, filtering and consolidation rules are used to remove likely incorrect events (artifacts) or consolidate overlapping calls into a single event when the current TSV columns support doing so safely.
+
+Currently handled artifact categories:
 
 - **Too-large source events:** before clustering, a source row is removed when `abs(svlen) > contig_length * --max_event_contig_fraction`. The default threshold is `0.5`. Supported optional contig-length column names include `contig_length_bp`, `contig_length`, `contig_size_bp`, `contig_size`, `chrom_length_bp`, `chrom_length`, `chrom_size_bp`, `chrom_size`, `chromosome_length_bp`, `chromosome_length`, `chromosome_size_bp`, `chromosome_size`, `sequence_length_bp`, `sequence_length`, `ref_contig_length_bp`, `ref_contig_length`, `ref_chrom_length_bp`, and `ref_chrom_length`.
 - **Rows without contig length:** retained deliberately and counted in the structured log as unevaluated by the too-large-event filter. The script does not guess contig size from total genome size or observed coordinates.
+- **Overlapping same-type deletions:** after loading and too-large-event filtering, same-chromosome `DEL` calls are consolidated when their intervals overlap or touch within `--tol`, even if neither breakpoint is close. This handles nested deletion-inside-deletion calls and shifted deletion boundaries as one event when they are represented as overlapping deletion intervals.
+- **Conservative clustering for non-deletion SV types:** `DUP`, `INS`, `INV`, `RPL`, and `TRA` records still require interval overlap/touch plus a nearby start or end breakpoint. This avoids broad, fragile merges for SV classes where interval overlap alone is less reliable.
 - **Malformed source rows:** rows missing required fields or valid coordinates are skipped during loading.
 - **Normalization artifacts:** reversed coordinates are swapped; signed or inconsistent `svlen` values are normalized for interval SV classes (`DEL`, `DUP`, `INV`, `RPL`) before filtering and output.
-- **Nested/overlapping final events:** not filtered automatically, but reported through `linked_event` relations such as `nested_in`, `contains`, `overlap`, and `exact_coordinates`.
+- **Overlapping final events:** final rows that still overlap, including cross-type overlaps, are reported through `linked_event` relations such as `nested_in`, `contains`, `overlap`, and `exact_coordinates`.
+
+Deletion clustering recommendation implemented here:
+
+- A deletion is treated as an interval event, so overlap is more informative than exact breakpoint agreement. For example, `DEL A: 100-1000` and `DEL B: 450-550` are consolidated because the second deletion is fully inside the first, even though neither breakpoint is close.
+- The current rule also merges deletions with only a small edge overlap, such as DEL A: 100-1000 and DEL B: 995-1500. This permissive behavior can help reconcile imprecise breakpoints in noisy or repetitive regions, but it may also incorrectly consolidate distinct nearby deletions. 
+- A future refinement could require a minimum overlap fraction before merging such calls.
 
 Known unresolved or only partially resolved artifact categories:
 
 - **Deletion plus substitution double-calls from non-clean deletion boundaries:** not collapsed automatically because the final table builder does not read BAM/IGV evidence or base-level alignment context.
 - **Substitution events duplicated as deletion/insertion calls:** not safely filtered from the current columns alone; these are exposed only through coordinate/type relationships when they overlap.
-- **Deletion-inside-deletion artifacts:** not removed automatically. Nested relationships are annotated in `linked_event` for review, but the script avoids deleting nested calls without stronger evidence.
+- **Cross-type or biologically ambiguous nested artifacts:** same-type overlapping `DEL` calls are consolidated, but nested calls involving different standardized SV types are not removed automatically. They remain visible through `linked_event` for review.
 - **Coverage/visual-review artifacts:** no BAM- or IGV-derived artifact logic is applied in `create_sv_output.py`; only fields already present in the TSV inputs are used.
 
 ### Explanation of `csv_per_sv_summary` CSV columns
@@ -203,7 +214,7 @@ The examples below use simplified coordinates for clarity.
 | `DEL_2` at `chr1:23-67` | `RPL_1 (RPL, chr1:23-67, exact_coordinates)` | The linked event has exactly the same coordinates as the current event. |
 | `DEL_2` at `chr1:23-67` | `INV_1 (INV, chr1:10-90, nested_in)` | The current event is fully inside the linked event interval. |
 | `RPL_1` at `chr1:10-90` | `DEL_2 (DEL, chr1:23-67, contains)` | The current event fully contains the linked event interval. |
-| `DEL_2` at `chr1:23-67` | `DEL_3 (DEL, chr1:60-100, overlap)` | The two events partially overlap, but neither fully contains the other. |
+| `DEL_2` at `chr1:23-67` | `RPL_2 (RPL, chr1:60-100, overlap)` | The two events partially overlap, but neither fully contains the other. Same-type overlapping deletions are usually consolidated before this final linking step. |
 | `DEL_2` at `chr1:23-67` with `--cross_type_tol 5` | `RPL_2 (RPL, chr1:25-69, same_coordinates_within_5bp)` | The events do not overlap exactly, but their start and end coordinates are both within the specified tolerance. |
 
 ### Additional pipeline-specific columns
@@ -295,10 +306,12 @@ The `create_sv_output.py` script processes SV records through the following step
 
 2. **Filter supported too-large source events** before clustering. A row is removed only when both event length and contig length are available and `abs(svlen)` exceeds `contig_length * --max_event_contig_fraction`.
 
-3. **Cluster records by (chromosome, standardized SV type)** using interval overlap with a tolerance window (`--tol`, default 10 bp). Records are considered part of the same event if:
+3. **Cluster records by (chromosome, standardized SV type)** using type-aware interval rules with a tolerance window (`--tol`, default 10 bp). Records are considered part of the same event if:
    - They share the same chromosome and standardized SV type
-   - Their intervals overlap (accounting for tolerance)
-   - At least one of the breakpoints (start or end) is within tolerance between members
+   - For `DEL`: their intervals overlap or touch within `--tol`; nearby breakpoints are not required
+   - For non-`DEL` types: their intervals overlap or touch within `--tol`, and at least one breakpoint pair (start or end) is within `--tol`
+   - Example recommended merge: `DEL 100-1000` plus `DEL 450-550` becomes one deletion event because the smaller interval is inside the larger one even though neither breakpoint is close.
+   - Known caveat: `DEL 100-1000` plus `DEL 995-1500` also merges because the intervals overlap. This can be aggressive; if real data shows over-merging, add a minimum overlap-fraction threshold as a future refinement.
 
 4. **Select best representative per source** within each cluster using a ranking strategy:
    - Rank 1: Supporting reads / evidence count (higher is better)

--- a/modules/utils/create_sv_output.py
+++ b/modules/utils/create_sv_output.py
@@ -30,11 +30,11 @@ SHORT-READ VARIANT TYPE CONVENTIONS (from delly):
   The code correctly handles all these conventions by:
   - Preserving start and end as reported
   - Using svlen for event_length_bp calculation (not end-start)
-  - Clustering by position proximity with configurable tolerance
+  - Clustering by type-aware interval/proximity rules with configurable tolerance
 
-Events are clustered by (chrom, standardized_svtype) using interval overlap with an optional tolerance (bp),
-PLUS breakpoint proximity (start or end must be within tol bp). This avoids merging very large calls with
-many unrelated smaller calls.
+Events are clustered by (chrom, standardized_svtype). Deletions are consolidated when their
+intervals overlap or touch within the configured tolerance, even if neither breakpoint is nearby.
+Other SV types keep the conservative legacy rule: interval overlap plus nearby start or end breakpoint.
 
 Within each event, at most one record per source is chosen (best by supporting_reads then score).
 
@@ -581,20 +581,52 @@ class EventCluster:
 
 # Clustering
 
+def intervals_overlap_or_touch(a_start: int, a_end: int, b_start: int, b_end: int, tol: int) -> bool:
+    """Return True when two intervals overlap or are separated by at most ``tol`` bp."""
+    return (b_start <= a_end + tol) and (b_end >= a_start - tol)
+
+
 def intervals_overlap(a_start: int, a_end: int, b_start: int, b_end: int, tol: int) -> bool:
-    """Check if two intervals overlap or are close enough to cluster together.
-    
-    Works correctly for all variant types:
-    - Interval variants (DEL, DUP, INV): real intervals with start < end
-    - Point variants (INS): start == end at insertion point
-    - Breakpoint variants (TRA): start == end at breakpoint
-    
-    For point variants, the condition simplifies correctly since start == end.
+    """Conservative legacy clustering rule for non-deletion SV types.
+
+    The intervals must overlap or touch within ``tol`` and at least one
+    breakpoint pair must also be within ``tol``. This avoids merging large
+    non-deletion calls with unrelated smaller calls.
     """
-    overlap = (b_start <= a_end + tol) and (b_end >= a_start - tol)
-    if not overlap:
+    if not intervals_overlap_or_touch(a_start, a_end, b_start, b_end, tol):
         return False
     return abs(a_start - b_start) <= tol or abs(a_end - b_end) <= tol
+
+
+def deletion_intervals_overlap(a_start: int, a_end: int, b_start: int, b_end: int, tol: int) -> bool:
+    """Deletion-specific clustering rule: interval overlap/touch is enough.
+
+    Deletions describe removed sequence spans, and exact breakpoints can shift
+    between callers or alignments. Nested/overlapping deletion calls therefore
+    consolidate when their intervals overlap or touch within tolerance, even
+    when neither endpoint is close; for example, 100-1000 and 450-550 are
+    treated as one deletion event.
+    """
+    return intervals_overlap_or_touch(a_start, a_end, b_start, b_end, tol)
+
+
+def _interval_overlap_percentage(a_start: int, a_end: int, b_start: int, b_end: int) -> float:
+    overlap_len = max(0, min(a_end, b_end) - max(a_start, b_start) + 1)
+    len_a = a_end - a_start + 1
+    len_b = b_end - b_start + 1
+    denom = max(len_a, len_b) if max(len_a, len_b) > 0 else 1
+    return (overlap_len / denom) * 100 if denom else 0.0
+
+
+def _record_clusters_with_current_deletion_span(
+    current_start: int,
+    current_end: int,
+    record: Record,
+    tol: int,
+) -> bool:
+    """Return True when a deletion record should merge into the current deletion cluster."""
+    return deletion_intervals_overlap(current_start, current_end, record.start, record.end, tol)
+
 
 def cluster_records(records: List[Record], tol: int) -> List[EventCluster]:
     clusters = []
@@ -606,38 +638,46 @@ def cluster_records(records: List[Record], tol: int) -> List[EventCluster]:
     for (chrom, std_type), recs in key_to_recs.items():
         recs = sorted(recs, key=lambda r: (r.start, r.end))
         cur = [recs[0]]
+        cur_start = recs[0].start
+        cur_end = recs[0].end
         cur_percs: List[float] = []
 
         for r in recs[1:]:
             last = cur[-1]
-            if intervals_overlap(last.start, last.end, r.start, r.end, tol):
-                overlap_len = max(0, min(last.end, r.end) - max(last.start, r.start) + 1)
-                len_last = last.end - last.start + 1
-                len_r = r.end - r.start + 1
-                denom = max(len_last, len_r) if max(len_last, len_r) > 0 else 1
-                pct = (overlap_len / denom) * 100 if denom else 0.0
+            if std_type == "DEL":
+                should_merge = _record_clusters_with_current_deletion_span(cur_start, cur_end, r, tol)
+                pct = _interval_overlap_percentage(cur_start, cur_end, r.start, r.end)
+            else:
+                should_merge = intervals_overlap(last.start, last.end, r.start, r.end, tol)
+                pct = _interval_overlap_percentage(last.start, last.end, r.start, r.end)
+
+            if should_merge:
                 cur.append(r)
                 cur_percs.append(pct)
+                cur_start = min(cur_start, r.start)
+                cur_end = max(cur_end, r.end)
             else:
                 clusters.append(
                     EventCluster(
                         chrom,
                         std_type,
-                        min(x.start for x in cur),
-                        max(x.end for x in cur),
+                        cur_start,
+                        cur_end,
                         cur,
                         percentage_overlaps=cur_percs,
                     )
                 )
                 cur = [r]
+                cur_start = r.start
+                cur_end = r.end
                 cur_percs = []
 
         clusters.append(
             EventCluster(
                 chrom,
                 std_type,
-                min(x.start for x in cur),
-                max(x.end for x in cur),
+                cur_start,
+                cur_end,
                 cur,
                 percentage_overlaps=cur_percs,
             )


### PR DESCRIPTION
- Kept deletion clustering interval-based: same-chromosome `DEL` intervals merge when they overlap or touch within `--tol`.
- Preserved conservative breakpoint-proximity clustering for non-DEL SV types.
- Documented nested deletion consolidation and low-overlap/aggressive merge caveat.